### PR TITLE
narbet: add V4 UUPS proxy contract addresses

### DIFF
--- a/dapps.json
+++ b/dapps.json
@@ -1,2295 +1,2306 @@
 [
-    {
-        "name": "Something",
-        "type": "DeFi",
-        "logo": "https://apricot-capable-rat-626.mypinata.cloud/ipfs/bafkreia6kcth4yagcbquyuc5vfxzuxwmcn22vorhhdjssvhjuojlzj2pga",
-        "website": "https://monad.something.tools",
-        "description": "Something delivers a full launchpad with flexible migration fees, a highly customizable AMM, and revenue sharing for creators.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x00F4353C69039b25c9338097FfF51099981E00ce"
-        ]
-    },
-    {
-        "name": "SomeSwap",
-        "type": "DeFi",
-        "logo": "https://apricot-capable-rat-626.mypinata.cloud/ipfs/bafkreicmt3l656cb6nhlotxlnvb6togtzgvc5sds32a7tnydwiwmokmepu",
-        "website": "https://someswap.org",
-        "description": "SomeSwap is a next-generation AMM and DEX built on Monad, featuring Chameleon Pools, dynamic fee tiers, anti-sniping protection, and Chimera smart routing. It powers trading, liquidity, and token launches across the Something ecosystem.",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x00008A3c1077325Bb19cd93e5a0f1E95144700fa",
-            "0x000799B28aE9C3E9ca70B7Ff67b191519ab80fee",
-            "0x001176F5eF99F53Eae957Bb2Fb2aE93E9b6F110c"
-        ]
-    },
-    {
-        "name": "0x",
-        "type": "DeFi",
-        "logo": "https://cdn.prod.website-files.com/66967cfef0a246cbbb9aee94/66967cfef0a246cbbb9aeeee_logo.svg",
-        "website": "https://0x.org/",
-        "description": "High performance APIs that aggregate DEX and private liquidity sources to provide optimal trade executions for digital asset trades.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x00000000000004533Fe15556B1E086BB1A72cEae"
-        ]
-    },
-    {
-        "name": "Accountable",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1910248229968490496/TZd8HlZa_400x400.jpg",
-        "website": "https://accountable.capital",
-        "description": "Crypto-based yields done right. Total privacy, full transparency, maximizing your yield opportunities, worry-free.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x4DE9B4d7b70d1680cD8E3A2C60717cBbe6014991",
-            "0xeE004AEF79cb14BF31BFbFB14346E01fB7e5a2e8",
-            "0x1106a70223e98E2b1807bf3e12698aFe2C5693e6",
-            "0xf786154e56e5c88Ce984800dEa71B48EA4FFAbfE",
-            "0xD0A53e724EA9CB041e30f0243E3c84bdea238Dfa",
-            "0x59B0b84371BB3261FAD538C512eFFFc414CC1725",
-            "0x8a5Caf00C3EB20aEC11Fc35C153a8601Cd127fEd",
-            "0x606556A6B544ecDcbf15aF73A63B67516dc16Ad7"
-        ]
-    },
-    {
-        "name": "Across",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1983984117092859904/0LvQEcB__400x400.jpg",
-        "website": "https://across.to",
-        "description": "Cross-chain liquidity protocol that allows users to swap tokens between different chains.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x09aea4b2242abc8bb4bb78d537a67a245a7bec64",
-            "0xeC41F75c686e376Ab2a4F18bde263ab5822c4511",
-            "0xd2ecb3afe598b746F8123CaE365a598DA831A449"
-        ]
-    },
-    {
-        "name": "AethonSwap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1963536268777979904/vX-IJ7U7_400x400.jpg",
-        "website": "https://app.aethonswap.com/",
-        "description": "AethonSwap is a next-generation decentralized exchange (DEX) designed to be the central liquidity hub of Monad.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6f85F158c2289579BE8e79a31B78F7DCd4686857",
-            "0x05aA1d36F78D1242C40b3680d38EB1feE7060c20",
-            "0xC67F01e87294a846ACEcB22d4f8D7AAbea9EA794",
-            "0xE35569726922F66a71e1279824Ba6082767E8569",
-            "0xd1814cC0FAee1EC941112F8739C47ddd0a908860",
-            "0xf31443F5d3fe6B2d026B9079F2fcEf2647A9fEcc",
-            "0x8510E4C073fb7fe75B8e767A1856F85586e24679",
-            "0x50AA60Edb77F0446b8E760B5Dc3015AD53D04d80",
-            "0xBf511a2d4f7D895F4cb8DeC448CE25a7bE211EAF",
-            "0xDD68207A952718b91d5dF31819d0676C269f1fB5",
-            "0x90dD87C994959A36d725bB98F9008B0b3C3504A0",
-            "0x41534b64b8a10b4e5C03bbB792F75f6DfCF462bF",
-            "0x545069eBd6cFA0B3028CEC5A23C37839B9EeEBaa",
-            "0x79b952a25c03b109cE6a6118F1A68a0E0113E8f3",
-            "0x26c48519bBCf6df3E39d4C724ff82B6F060D3Bbe",
-            "0x77996bd2e8272cB694D320be78CE972307D85bF9",
-            "0x217fd038FF2ac580de8E635a5d726f6f0E5214e3",
-            "0xcea03e70f95e1998D90549Aba02E5f89D1db2C90",
-            "0xFF9382865eAc4C9E79f15586Ae7ff68209419f2e",
-            "0x245f061e602E690266012E8bFBf9b5131ee66d86",
-            "0x81554Cc2aC39D03Ef5F2e879c9B3748fff61385a"
-        ]
-    },
-    {
-        "name": "ApeBond",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1912568082201018368/rp47FESU_400x400.jpg",
-        "website": "https://ape.bond",
-        "description": "The #1 Bonding Protocol in DeFi, with $20M+ bonded and 80k+ bonds sold, transforming how projects raise funds and secure liquidity.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xd731d8103132275b21A27eA8C8428Ac6B97C5D35",
-            "0xc765C358622cB346f236F8Bfffe53036e421bb4e",
-            "0x1b7858f745211dBa1387fE30124eBCa2D706D7Dd",
-            "0x1f226C1008f5De89614Bb15d09745128cf2a4D62"
-        ]
-    },
-    {
-        "name": "Atlantis",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1902110216402927616/2KI7eXdp_400x400.jpg",
-        "website": "https://atlantisdex.xyz",
-        "description": "Modular V4 DEX offering cross-chain swaps, DeFAI, a launchpad, farming, staking, fiat on-ramp, & more.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xd7cB0E0692f2D55A17bA81c1fE5501D66774fC4A",
-            "0x10253594A832f967994b44f33411940533302ACb",
-            "0x4439199c3743161ca22bB8F8B6deC5bF6fF65b04",
-            "0x955B95b8532fe75DDCf2161f61127Be74A768158",
-            "0xFe3BEcd788320465ab649015F34F7771220A88b2",
-            "0x4A3BC48C156384f9564Fd65A53a2f3D534D8f2b7",
-            "0x13fcE0acbe6Fb11641ab753212550574CaD31415",
-            "0x03f8B4b140249Dc7B2503C928E7258CCe1d91F1A",
-            "0xa77aD9f635a3FB3bCCC5E6d1A87cB269746Aba17",
-            "0x3012E9049d05B4B5369D690114D5A5861EbB85cb",
-            "0xD637cbc214Bc3dD354aBb309f4fE717ffdD0B28C",
-            "0x6AD6A4f233F1E33613e996CCc17409B93fF8bf5f",
-            "0x69D57B9D705eaD73a5d2f2476C30c55bD755cc2F",
-            "0xB4F9b6b019E75CBe51af4425b2Fc12797e2Ee2a1",
-            "0x50FCbF85d23aF7C91f94842FeCd83d16665d27bA",
-            "0x658E287E9C820484f5808f687dC4863B552de37D",
-            "0x38A5C36FA8c8c9E4649b51FCD61810B14e7ce047",
-            "0x83D4a9Ea77a4dbA073cD90b30410Ac9F95F93E7C",
-            "0x503D191CaFaB1d097b5F798d850E5897195C1d74"
-        ]
-    },
-    {
-        "name": "Axelar",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1874834853943824384/l71EkA26_400x400.jpg",
-        "website": "https://axelar.network",
-        "description": "Powering the Chain-Agnostic Future",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xe432150cce91c13a887f7D836923d5597adD8E31",
-            "0x2d5d7d31F671F86C782533cc367F14109a082712",
-            "0x50beAbe4883981624aEa01F737B040d1e3Fe83FB",
-            "0x7DdB2d76b80B0AA19bDEa48EB1301182F4CeefbC",
-            "0x98B2920D53612483F91F12Ed7754E51b4A77919e",
-            "0x6513Aedb4D1593BA12e50644401D976aebDc90d8",
-            "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C",
-            "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66"
-        ]
-    },
-    {
-        "name": "Banza",
-        "type": "AI",
-        "logo": "https://pbs.twimg.com/profile_images/1978484417505955840/SJ2MfyYx_400x400.jpg",
-        "website": "https://banza.xyz/",
-        "description": "Banza helps you build a personal AI twin that learns freely from every app you use through verifiable, privacy-preserving data capture using OPzkTLS, then earns rewards for you while delivering tailored cross-platform recommendations and proactive actions that save you time, all of it with cryptographic proof.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x68b571F834C9853d2a7E8e364d28dB52De47d46d",
-            "0x11fBE9E637C4A3DECA3453f2925AAAa18e16963E"
-        ]
-    },
-    {
-        "name": "Bean Exchange",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1981305723637166080/ubiQ-e6g_400x400.jpg",
-        "website": "https://bean.exchange",
-        "description": "The ultimate capital-efficiency Perps & DLMM Spot DEX on Monad",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8Bb9727Ca742C146563DccBAFb9308A234e1d242",
-            "0x721aC9E688E6b86F48b08DB2ba2D4B7bBBd12665",
-            "0xA398af902950081F2FBE3E16e5E474C2C72ae27a"
-        ]
-    },
-    {
-        "name": "Blocksense",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1907393414901170176/CBZG2akF_400x400.png",
-        "website": "https://blocksense.network",
-        "description": "The universal verification layer for the autonomous economy",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xADF5aaa34D0A2FbAeE73353ab1622E47d0600249",
-            "0x9CA25F9149e5204CDD1C5b7717C08Dff35A4eFc3",
-            "0x5985F6247985e0cB7750893093214A77F0F9D3cE",
-            "0x43662b6eD1EDEA444Ed2bA4e1e008403C5F32bAc"
-        ]
-    },
-    {
-        "name": "bonad.fun",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1991955935841906688/7NmCLcoP_400x400.jpg",
-        "website": "https://bonad.fun",
-        "description": "Create, trade, and build your vision",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
-            "0xC99b485499f78995C6F1640dbB1413c57f8BA684",
-            "0xFAafdE6a5b658684cC5eb0C5c2c755B00A246F45",
-            "0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9",
-            "0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731",
-            "0x136191B46478cAB023cbC01a36160C4Aad81677a",
-            "0xCe3099B2F07029b086E5e92a1573C5f5A3071783"
-        ]
-    },
-    {
-        "name": "Bro Fun",
-        "type": "Consumer",
-        "logo": "https://pbs.twimg.com/profile_images/1983519855279042560/ntgzrOaU_400x400.jpg",
-        "website": "https://bro.fun",
-        "description": "Where fortune favors the bros. Sink cups, become a legend.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xDF7A89Fc62e5120C4617f143C7AcDDAB0D1Ca7A2"
-        ]
-    },
-    {
-        "name": "Bungee.Exchange",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1938126602774450177/qEmo_mDl_400x400.png",
-        "website": "https://www.bungee.exchange",
-        "description": "Bungee provides seamless swaps between any blockchain. With over $24B in volume and trusted by major wallets and dApps, Bungee makes moving assets between networks efficient, secure, and accessible to everyone, powered by the SOCKET.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xd0389e84178f809903cbFE7D1EfAE3EFa9c1769c",
-            "0x3859AD748D03C358aAbB66d084bC5849B624E611",
-            "0xF20B3CB7508c519296556C1Caa9dB6F210e0232a",
-            "0x27D966329a325f214b4854a4F0E62550BFebdca3",
-            "0x01D8a85aDb82408E14bC242ed43fBaD0Ca2F94CB",
-            "0x1A2F1085A94De6fBcc334AAE1DDf527C567b75E7",
-            "0x3bb92b8452bDE5Ac20C18E10e606fdc9AC19b414",
-            "0x82260Eac86558C0835D08eeFF360014aEa7454b6",
-            "0xa873aab6a98cb764ad6d52820d129d0e3667d9f9",
-            "0x7aEa2188414C6d22ce15b2b0b2870Bce69e5e5D5",
-            "0x09b043840cd2f32687ec6b63fb0412585de39822",
-            "0x12efda5e4d410c5da723ceb7e43942779e3fe49b",
-            "0x94d0bef156041af3ef0b9fec4784468e660045dd",
-            "0xaB568b1B49f8bE7488Ca1c0D5DdA6fF94691e4c8",
-            "0x88a8596e2B51512aab3867Cc895d7047E1D9ef7B",
-            "0x26d8da52e56de71194950689ccf74cd309761324",
-            "0x5013c0b3defd8f832d1b6dec750382946de5c13b"
-        ]
-    },
-    {
-        "name": "Capricorn",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1931864507590045696/yn7mxTi9_400x400.jpg",
-        "website": "https://capricorn.exchange/",
-        "description": "The premier liquidity venue on Monad.",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x6B5F564339DbAD6b780249827f2198a841FEB7F3",
-            "0x0136B6347509D386c6da3896162BEBaAF19e51c4",
-            "0xEd2850D3704a1a5BcB6158f27deDA3d6FF4C31D9",
-            "0x4C02af995BB1f574c9bf31F43ddc112414aE0Ac7",
-            "0xdac97b6a3951641B177283028A8f428332333071",
-            "0x830b22425257A752314A5f0902559164c84e44A4",
-            "0x53153392D0175D394D721CCF31173a49F7E6Ef53",
-            "0xB430EDD2b54cdB3B25703fb3342ca3a88663A04D",
-            "0xEcEB2CfcB38D1f469f55a3E5dc0C950Df8A465c3"
-        ]
-    },
-    {
-        "name": "Cashmere",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1551945866793164802/KmcIMByo_400x400.jpg",
-        "website": "https://cashmere.exchange",
-        "description": "Autonomous Monetary Infrastructure for stablecoins \u2014 a unified layer that powers zero-slippage omnichain transfers, yield agent, on/off ramps, privacy transfers directly on https://app.cashmere.exchange.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xD156fFB54871F4562744d6Be5d6321B5BffCa3B6"
-        ]
-    },
-    {
-        "name": "Chainlink",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1800426318099595264/N7yf_kOD_400x400.jpg",
-        "website": "https://chain.link/",
-        "description": "Chainlink is the standard for onchain finance, verifiable data, and cross-chain interoperability. Learn more by visiting chain.link.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x33566fE5976AAa420F3d5C64996641Fc3858CaDB",
-            "0xEd813D895457907399E41D36Ec0bE103E32148c8",
-            "0x2a954d493eE80BcC7cDeF56DB6fC6edC6758CA5d",
-            "0x81Bf4bbD9910F95c18cf661752bD9a07629fe191",
-            "0xA7cd3368eBC801df68812d46AB6b3F47d4BF37ea",
-            "0x900f68B165443A4aa1F8071471DFb8000df3bfF2",
-            "0x714de9941991c7Cec93efA6cB63469bD6bFE1258",
-            "0xF43deF45aCd1C1c54937937591dDA64b43DD87C2",
-            "0xcD22c0012480987F6F81F1099E74954B75666361",
-            "0xBb911c169033289187f70Af5c0DD8E6f643e4ADc",
-            "0xb0c0202E6d8b978f9b6FE6B5e50ebD6FD7A962a1",
-            "0x060728Ec2e1e132279EBa0a79b2ffFE26AbAD65C",
-            "0x92929c1b04C6b4AbD6c2C34111d447d972cACA71",
-            "0x3b126914ad2f884A68b8C182129109eF2Bf97ab7",
-            "0xEB58Fa36e5715fc1Bdb9959E0Ae01803B7432882",
-            "0xBAf3aaECB1A4f8468D88c74cD014a3550F204970",
-            "0xc1d4C3331635184fA4C3c22fb92211B2Ac9E0546",
-            "0xC6D6f57EFe5Ce2769aF0e0D8708477e4819F92d0",
-            "0x6156c406B7672b4720B7A2E637F32fc68E55930c",
-            "0x8fB6979CCB8Cbe1596Ad712955aF201e0A29c26f",
-            "0x3dDc1bAE752aaEe31b577bF844c799C349A1d6BD",
-            "0x14ef5938Cb0D1164516DD71fC656A8294570Ca7e",
-            "0xfDa103bb79FbB958eD270F828ca2506D046cAC91",
-            "0x91E70e5E0eAc9F07E3abd7B4b62173e6b67c30d8",
-            "0x1c747D909102bfCdb305C54bDdDBdA3eF588B1d0",
-            "0xDfc4441DBBeD5F2A743C001F722BD8d4f587C8fb",
-            "0xc40F902d11b11BF243283AF537A4Fc617344B2C7",
-            "0x18d19FECf754B2F16301B9Cd9A4F3d3A3540Aaa2",
-            "0x1B1414782B859871781bA3E4B0979b9ca57A0A04",
-            "0x3d21E2E680E2a60b440da427820aEe2391375EB7",
-            "0xC38c1843751941019EdE3B8E041EE1bD14575B44",
-            "0x7d12A857FB76396b3fF8749f6F832908E2DC55f5",
-            "0xf62D24B17181305B22E520fB14384eB86b9C6944",
-            "0x68bA3f3b52b17bFCc8cFB9cB97Df14D6A0f96E5E",
-            "0x3D160cBa91B35BC295295Cb790080E9be9A46811",
-            "0xF73F65C2DF4E1CB89f31DeE710A00627E6B9bbbC",
-            "0x5c266b5c655664d6c99a13fF0d7F1F7eaF4Ac9ba",
-            "0x44b9e53236b95Ca6Cfc1dAED893C5b312e596477",
-            "0xF29B907b292fb27e07f06331E4e92Ea7288a6001",
-            "0x24f29BB8ec47674F1A0a9011116c41F867a94337",
-            "0x921cB0E4f2397454240CcdB27596217CE4e65090",
-            "0x5658EC04E7e6EF42B1C567AafC33Cd92751E1730",
-            "0x3B59380FdCf2fd414F1675D76AF5F20FB92663a7",
-            "0xB5bE9cb264D299710F98c03f2604157E33E2c4cc",
-            "0x519dC0fBb6f4fa37F59Dc17CC60eF4d95cd8D001",
-            "0x23c377a8f4d153803a9D7869d56d0A4aEFdEeA93",
-            "0xb368d0CF937A6843fb68f1CD0056C835B4Cf3F70",
-            "0x638405174C766b9d1797860fDF696732921179F5",
-            "0x7422d308f0Aeb0c7816402Ff4E68078c2549435b",
-            "0x19d7FD9167597e0338dece5F3DE95f1BE61FAc40",
-            "0x1Bd7CEBABA5C2c40D44b83A08F42A3377447dDFe",
-            "0xd3f27362D951Cfb596242FFbA9c71E6c7d5d09AF",
-            "0x251eD64BD39e8fceB708b483D18Ee34bf4040aE8",
-            "0xB983b1b6f1Fc04030F9d8935DBBFd2a1239D00d9",
-            "0x68f23F7820B8528FBd1039B235923d8FB2590985",
-            "0xF007B6D353302A6C49D18C35809faa031E94eFbB",
-            "0x16F8008c3e89f62e5e2b909Ce70999370D38F4F2",
-            "0x10da0c6188A7d74d8556e1d6A193D58721e5E102",
-            "0xd447F67Dc94f234dFA1a3921C08330CecA06a1dC",
-            "0xE4DE4f111f6a015963589256A0EcC2F70Cb29BdA",
-            "0xad7AF5c6d78Ef5f4d3c4133593047d9E2A8BDa8d",
-            "0xBE1442Ec0a67D37D1e57c4940e0C0747cf7d55b9",
-            "0x69E075202802B5a90661AfDb4aDC117Eef8a59DF",
-            "0x097d4088e99c1a01a5713B079C898Fad852b9920",
-            "0xB7E7A36A0Fc6543C10f4F9B60E942F1b628f2a13",
-            "0xFe3165008F7FFfc27cc2649c18FfcbB959F0495a",
-            "0x31938934512dFFf3c410a6D07CeAF5F38B66BFee",
-            "0xC64012057A58b91bF42361c7D50bA36C0255cb73",
-            "0x8Cc589634A0B5959Fb29fc1111CFf26356b11918",
-            "0x5075Ea68c3D769723BC9CC23120A60e4026dD70F",
-            "0xa63564f2A626f69130C1CCA87f984351B26Cf2f1",
-            "0xCc973DAEf0A2d92BC99c21561b3FEa74DA033796",
-            "0xf5F15f188AbCb0d165D1Edb7f37F7d6fA2fCebec",
-            "0x449aeeE17b0447Af2D2Cdf3334EBF1e15C886Fb9",
-            "0x6b5902EABcE27C23FC97ea136504395b4d22C1FD",
-            "0x7bA2142854c5116D610AD2Eb45eB5435b875D08a",
-            "0xa16212CD5b330583B346167fA91E138d41AEe8CC",
-            "0xDfFa1693B3DDBE1A6a26c29B727e073a1D2A4Be5",
-            "0x1a1Be4c184923a6BFF8c27cfDf6ac8bDE4DE00FC",
-            "0x0087d34545e1A9a62051c023A31B2193C21Cbf4F",
-            "0x5A96Af6E7c9aA17901D9E2f00feafAFc7655B19F",
-            "0x4b1DFE1e642d8786Af6D19d63CEAf0D5475EDdF8",
-            "0x2D1Df1bD061AAc38C22407AD69d69bCC3C62edBD",
-            "0x1d6533DdC0E46514afbeAB55a013D6ded720307C",
-            "0x42dd36b9D6938dccff8Fe4E9770589aBa614FCBB",
-            "0x24b8BEAD860e19fA9650c349eC496eb4b09F7f9E",
-            "0xe6cd21b31948503dB54A07875999979722504B9A",
-            "0x4E14B7f0744a757F3c04Bfd7980721AEE3b7ea9F",
-            "0x29bEb7e730f09D33417357dbed020B549fdF7db4",
-            "0x8Aa871027BA54dc1a9c803456AD613668a643fB4",
-            "0x61dD33A34E47a181EE02e42eE0546a3DA808f1B4",
-            "0xFeccbf9C82Ff5231073580334DC605740309ebCe",
-            "0x979211Dfbc0738559B778a6a58a5b1bbbBe720f9",
-            "0xfd03e1bd18b11fA56c55582a91e8fc0bB0A1c27E"
-        ]
-    },
-    {
-        "name": "Chainlink CCIP",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1800426318099595264/N7yf_kOD_400x400.jpg",
-        "website": "https://chain.link/",
-        "description": "Chainlink is the standard for onchain finance, verifiable data, and cross-chain interoperability. Learn more by visiting chain.link.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x4AfC00570596d172595A4E38384289b880263006",
-            "0x99dFCa5d88f4D9C023531F4403966b8d61562AcD",
-            "0xF181489663b5b99af5C5a57310F1d66eEEEC2160",
-            "0xDdBC012B8a5C317b9611ee593fA49dE370BF950f",
-            "0x11ACd984DD680363117B310f6ebdf78fD6c0195f",
-            "0x4c1D9f81D59270ddc1c0f1A4D7C39264D9ADa379",
-            "0xb39B7D0cdd79B94B08b334965C1720be51A31986",
-            "0xCE78587FEADDefC30e36520C09fc3a333dd6eEf4",
-            "0xBad8b04ED03A1CEaC89e8328f4eA7148B2E6D642"
-        ]
-    },
-    {
-        "name": "Chronicle",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1501371292557185027/0XmX2Tp3_400x400.png",
-        "website": "https://chroniclelabs.org",
-        "description": "The verifiable data provider for onchain finance.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x55900781784cC88e10b53B400241a8B5099b1a58",
-            "0xaE9Ef5d8193348E484805683aA4026F4d410d9E9",
-            "0xECd09Ce60c069384D6B91656A841097F1181A59e",
-            "0x8644203113402C1D9CBe0A39064E467eE76e2fBC",
-            "0x7FC72F82B67aD3bbbaDA92b62d412AB284f910A6",
-            "0xcBA348Ee71970714cEBBC26C7e38baCeb0C6A597",
-            "0xa7f041Fb6AfFb962162Ff3f318cA184299e4eC58",
-            "0x7a5c9Bc685C16190Ac832a6bc232BC6C22e9ed18",
-            "0x8B9CB9999871423A549261B53e9cf87300e50349",
-            "0xCbec56397d82D353767911142aB2cBEB2F5e06ae",
-            "0x936a444C983347FFBfe3F26D1497CAbfA2BfE271",
-            "0xA3835b84BcaBF17C7509D09487E7B7169A82d64F",
-            "0xEe4631539c06aCC8c1f681C0b1b573FbC8506Da8",
-            "0x23035f3554c8EeC9d079276Cc4af0d2FED067992",
-            "0x43a05b07238d1f9814B55E145738AFdeEDACa68f",
-            "0x144a4B14115fcBe23408611a5307115a96ab5bA1",
-            "0xd52C49Ea370cDaa0E5912A98B3AAf3375768E49B",
-            "0xDa75F9d81dca1Ad7a2D3F628425c3736E2e7B685",
-            "0x46eA6F8Ad2F346801a346FB95E0e9E6106791291",
-            "0x812Aab12D9C323678C78d7EC6Aa76F4bc86f623a",
-            "0x8F9ad9205B442ACC5105Aac1F1efe5f09B194e1d",
-            "0x5B49FA5187F99DA89C644cd2C1c23ff3b1d8dd88",
-            "0x700EdC28DC93E72D76E8C1eA2Be0A50d60a4844D",
-            "0x83D794F01A3eDBdD92ae2f2EcC8e56b41eD7777c",
-            "0x109Bbc7056B5e808F8E64Fc71D12C89e654F688F",
-            "0xf8689D8A90cDB562ea2B83cecE80c8a551a931C6",
-            "0x847A305548462557945088c97074524d1Fe9d563",
-            "0xD4920c3Eba8c0E4824afe7B3737fACD7C1022234",
-            "0x418541FFD62bDB3078fb669cB9c18D45942d9C3d"
-        ]
-    },
-    {
-        "name": "Circle CCTP",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1719446730091962368/Bl01sQsB_400x400.png",
-        "website": "https://circle.com",
-        "description": "Building the Internet Financial Platform",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
-            "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
-            "0xfd78EE919681417d192449715b2594ab58f5D002",
-            "0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78"
-        ]
-    },
-    {
-        "name": "Clanker",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1953706842032324608/Arf6RRS3_400x400.jpg",
-        "website": "https://clanker.world/",
-        "description": "Clanker is an AI that launches crypto tokens for you. Give it a name and symbol, and it handles deployment, market creation, and fee sharing automatically.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xF9a0C289Eab6B571c6247094a853810987E5B26D",
-            "0xDe51a86D3b6EC9ac4756115D3744335Aa2c30144",
-            "0xe7D402A5BEd94E5c49Ac0639E80f784D06E2D397",
-            "0x654E7221fa51d4359ded21D524E3AfF18e93A507",
-            "0x8790d79283eB941c719b616CfD0Ef116D13C7683",
-            "0x3231D1ddfdC4Ad585cF1939FfEcd9c88b338Dbf2",
-            "0x46B77BaCFd712D79131F1AD7611794869483C353",
-            "0x94F802a9EFE4dd542FdBd77a25D9e69A6dC828Cc"
-        ]
-    },
-    {
-        "name": "Clober",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1679045925556355075/lvEiK0XY_400x400.jpg",
-        "website": "https://clober.io",
-        "description": "Clober is a fully on-chain CLOB DEX protocol with a gas-efficient matching engine optimized for on-chain execution.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6657d192273731C3cAc646cc82D5F28D0CBE8CCC",
-            "0x19b68a2b909D96c05B623050C276FBD457De8e83",
-            "0xe424c211e2Ed8a5B6d1C57FA493C41715568D238",
-            "0x7B58A24C5628881a141D630f101Db433D419B372",
-            "0xB09684f5486d1af80699BbC27f14dd5A905da873",
-            "0x54cd5332b1689b6506Ce089DA5651B1A814e9E7D",
-            "0xb1251BF43Bb7De76DE7e6CE7B64aF843dfc9d242",
-            "0x9050b0A12D92b8ba7369ecc87BcD04643Fa0CfDB"
-        ]
-    },
-    {
-        "name": "Covenant",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1760674458497654784/SeqF3eEq_400x400.jpg",
-        "website": "https://covenant.finance",
-        "description": "Covenant is a fully on-chain credit marketplace that enables the creation and funding of leverage against any collateral asset",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x11A7Ab0A9D7bD531DBcF0f0630BF7167F8F198f6",
-            "0xAB0f8aB1e67cc02A9D58fc27055292289B159094",
-            "0x6A5Aa3df89bA1C1f8B471c72159458D61a9447c2",
-            "0x9a369DF53EC62725c93f41B891e701BD88aFf2c8",
-            "0x5c1fb9a1232E87702897424eC0852D30B713bfD8"
-        ]
-    },
-    {
-        "name": "Curve Finance",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1220560374346461185/W1sQNVWo_400x400.jpg",
-        "website": "https://curve.finance",
-        "description": "Creating deep on-chain liquidity using advanced bonding curves.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8271e06E5887FE5ba05234f5315c19f3Ec90E8aD",
-            "0xe460dec242bc0A1a364c250a9D2F731d8D923650",
-            "0xFC687EFAFED297b765eDEcF8179c32195597C2df",
-            "0x845b942DeEF9BC20a39A8b34B23e8c33aC2921BF",
-            "0xC9459A955a885467f01Ccc531c51dBcC957993c0",
-            "0x46FEffb8Ed015250Cd48f9bf7F4a4584049Ca4aE",
-            "0x6E28493348446503db04A49621d8e6C9A40015FB",
-            "0x286182220E734AaC601282ba059de531d4BEAC1f",
-            "0xA4A2E7E11cBe5213B316E801D2172Ef10e566A96",
-            "0x2Fe4A238F6A3BD7fAA68e0B6951e3FAFdB2876Eb",
-            "0xBBbe22DEe69747e61f676cF50465b1bfbA4a4dD6",
-            "0xe7FBd704B938cB8fe26313C3464D4b7B7348c88C",
-            "0x5F870C2cf22ff829B5DC1Da09856B79dA6544f94",
-            "0x95249Dd40dDa3c0cbB4A7dd7D287E04aA68A3D4B",
-            "0x17c67C3A38F68cbc4dEC77Fd7378978971B6c271",
-            "0x7e595b3b77CC16680C30617b88E9b87F987Ac934",
-            "0x41D2c5128A7241EC1f7CE346B162C347C19548B7",
-            "0xbb8A5E91295131Ce07B6Bfe301C49bcD925A2902",
-            "0x193110Ce1542d7371e1515BD6A2E470fDefc310D",
-            "0xB2Be7692B07b640C9f2ee1187cee2fAec741F872",
-            "0x129578f94C253b8Bc903Bf2b73D07BF2583cc11d",
-            "0xFF5Cb29241F002fFeD2eAa224e3e996D24A6E8d1",
-            "0x2AF43209B366A4491CCe0A97C5a7B6059fd21295",
-            "0x4574921eb950d3Fd5B01562162EC566Cb8bc3648",
-            "0xe6dA14500f0b5783E2325F9C5a7eE5d99DA0fB42"
-        ]
-    },
-    {
-        "name": "Cycle Network",
-        "type": "Infrastructure",
-        "logo": "https://pbs.twimg.com/profile_images/1745373174735540224/egXcozCp_400x400.jpg",
-        "website": "https://www.cyclenetwork.io/",
-        "description": "Cycle Network is building a universal all-chain settlement layer and a bridgeless liquidity network for the entire blockchain ecosystem.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x647E77A1AF7c87688B974F20DB75eA36C28D033E",
-            "0xaD5cA27D8932114a9457d385FC0b88825c845960"
-        ]
-    },
-    {
-        "name": "DeBridge",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1894665537466040320/5vQrjq6M_400x400.jpg",
-        "website": "https://debridge.com/",
-        "description": "Trade any opportunity, ahead of the curve. For first-movers.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x663DC15D3C1aC63ff12E45Ab68FeA3F0a883C251",
-            "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
-            "0xE7351Fd770A37282b91D153Ee690B63579D6dd7f",
-            "0xeF4fB24aD0916217251F553c0596F8Edc630EB66"
-        ]
-    },
-    {
-        "name": "Definitive Finance",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1989507102352764928/AXdL2XHz_400x400.jpg",
-        "website": "https://definitive.fi",
-        "description": "Definitive Finance is a professional trading terminal delivering advanced on-chain execution and risk tooling for active traders on Monad.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xdeF00000cc0a125ba7962e8113d3B69786851736",
-            "0x0000000d1126e7651931461F31Be87712CD9E05C",
-            "0x000000005aE5f42270cDf0E41960840e7FB1b2dc"
-        ]
-    },
-    {
-        "name": "Dexalot",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1905272093492572160/3ilOLKT8_400x400.png",
-        "website": "https://app.dexalot.com/",
-        "description": "Dexalot is a decentralized exchange (DEX) for spot trading, powered by a fully on-chain central limit order book (CLOB).  Competitive prices, zero to minimal slippage and no fees.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x1FD108cf42A59c635bD4703b8DbC8a741ff834Be",
-            "0xC725229Aefeab5fAec9cc1667d79D9478e564a0C",
-            "0x3D3E4F0523500f95039D0Fe600ACf2ADE4b06eB9",
-            "0xA0421a4DB5bb7577f9bb9B577b5F600a642368be",
-            "0x246c87368580acd6E9ca46Bf112aD91978389634",
-            "0x170c15cb9887E6Adb097518104B174Df212bB190",
-            "0xa5C079C1986E2335d83fA2d7282e162958e515D5",
-            "0x06B82468100A3A7b0EAC77289f0D1ab920573B16",
-            "0x15764530c716cEFaD9Cbd2310D722704D03de875"
-        ]
-    },
-    {
-        "name": "Dirol",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1971111107335979008/da7R3pmO_400x400.jpg",
-        "website": "https://dex.dirol.io/",
-        "description": "Dirol is the all-in-one trading aggregator for the Monad ecosystem, designed to be a single gateway to everything in DeFi. We aggregate all token launches, launchpads, and DEX liquidity from muptile AMM's, Orderbooks, into one seamless platform, eliminating the need to jump between multiple dApps and interfaces.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x77E73c3fCd3FEDba383025CDe4a5b97733A34c2E",
-            "0xA82098c33c75A4A1e20e06f352732910C75C690D"
-        ]
-    },
-    {
-        "name": "Doppler",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1989072411757568001/hKlsQbpS_400x400.jpg",
-        "website": "https://www.doppler.lol/",
-        "description": "Create custom capital markets with efficient price discovery and maximum flexibility. ",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x5fbe931dc4b923a7abe4c47ad68d5bf9eda5b76d",
-            "0x8b4c7db9121fc885689c0a50d5a1429f15aec2a0",
-            "0xaa47d2977d622dbdfd33eef6a8276727c52eb4e5",
-            "0x580ca49389d83b019d07e17e99454f2f218e2dc0"
-        ]
-    },
-    {
-        "name": "Eisen",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1861248882824593408/h5CrU_s__400x400.jpg",
-        "website": "https://eisenfinance.com",
-        "description": "A multichain DEX & CEX aggregator\u2014streamline every swap.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x787C474B8A86354d0F5f19FB599a5FC7662A265f",
-            "0xECE5E77f9A9846C4D69555Eb44E0CFF8B5F03F1e"
-        ]
-    },
-    {
-        "name": "Enjoyoors",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1846943911429697536/Km5JGs5b_400x400.jpg",
-        "website": "https://enjoyoors.xyz",
-        "description": "Enoyoors is a protocol that unlocks yield on any asset on any chain",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6B5E332387e8beC98C52F10A72952B17176B4f1b",
-            "0x71F60773885011cC0a61613078733b4738B38f35"
-        ]
-    },
-    {
-        "name": "Fastlane",
-        "type": "LST",
-        "logo": "https://pbs.twimg.com/profile_images/1935840734726270976/nnMo1axH_400x400.jpg",
-        "website": "https://www.shmonad.xyz/",
-        "description": "Fastlane launched shmonad, the first holistic LST on Monad and Atlas, the first MEV protocol for apps to capture the MEV their users create.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c",
-            "0x2DA28fedc4643c787CB5c5e84fa6AaDb596875E8"
-        ]
-    },
-    {
-        "name": "Fibrous",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1910332320067747840/SGkFXgaC_400x400.jpg",
-        "website": "https://fibrous.finance",
-        "description": "One place for best execution across chains.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x274602a953847d807231d2370072F5f4E4594B44"
-        ]
-    },
-    {
-        "name": "Flap",
-        "type": "DeFi",
-        "logo": "https://beta.flap.sh/_next/image?url=%2Flogo.png&w=1080&q=75&dpl=dpl_D8pNRVsFr6RF8LkbCB6nnUb1Rb4w",
-        "website": "https://flap.sh/monad",
-        "description": "The premier memecoin launchpad for trench warriors on Monad.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x30e8ee7b5881bf2E158A0514f2150aabe2c68b23",
-            "0xB88189aA1162850D75A1c1e16F837b7979994184",
-            "0x1C8847736521f5cD725dFB8f33c7c610826e7C42",
-            "0x57Fed6832F12150a77D5952b49190d9447aCB5ee"
-        ]
-    },
-    {
-        "name": "Fluffle",
-        "type": "Social",
-        "logo": "https://pbs.twimg.com/profile_images/1972672305336569856/JLjBcagi_400x400.jpg",
-        "website": "https://fluffle.world/",
-        "description": "Fluffle is the first hyper-gamified productivity platform that makes focus addictive. ",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8255DACD8A45f4aBE6dc821E6f7F3c92a8E22fBB",
-            "0x2eD99dbE114249B7611478d67818B399865FFc89",
-            "0x67f58f1faf78781b7eb90c457846e0f965bb1a2f"
-        ]
-    },
-    {
-        "name": "Garden",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1955253205832699904/83uUswbn_400x400.jpg",
-        "website": "https://garden.finance/",
-        "description": "Garden is transforming Bitcoin interoperability with its next-gen bridge. It is built by the renBTC team using an intents based architecture with trustless settlement, enabling cross-chain Bitcoin swaps in as little as 30 seconds with zero custody risk.\n\nIn its first year, Garden processed over $1 billion in volume\u2014proving the market\u2019s demand for seamless, cost-effective Bitcoin bridging solutions.\n\nNow, Garden is unlocking a new era of interoperability\u2014supporting non-likewise assets, external liquidity, and a wallet-friendly API\u2014to onboard the next wave of partners and users.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xE413743B51f3cC8b3ac24addf50D18fa138cB0Bb",
-            "0x5fA58e4E89c85B8d678Ade970bD6afD4311aF17E"
-        ]
-    },
-    {
-        "name": "Gas.zip",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1750310657680101376/HEtUyTZy_400x400.jpg",
-        "website": "https://gas.zip",
-        "description": "Instant liquidity bridging for over 350+ chains",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x9E22ebeC84c7e4C4bD6D4aE7FF6f4D436D6D8390",
-            "0x391E7C679d29bD940d63be94AD22A25d25b5A604",
-            "0x8C826F795466E39acbfF1BB4eEeB759609377ba1"
-        ]
-    },
-    {
-        "name": "Gearbox",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1737949216708739072/ISu5WSUS_400x400.jpg",
-        "website": "https://gearbox.finance/",
-        "description": "Gearbox delivers a seamless, all-in-one prime brokerage experience, right from your favorite wallet.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xF7f0a609BfAb9a0A98786951ef10e5FE26cC1E38",
-            "0x1cE2B1BE96a082b1b1539F80d5D8f82Ec06a0f9A",
-            "0xcCCCCcCc42B7DA9fdEc1761698Fb55fdD41CDF55",
-            "0xBcD875f0D62B9AA22481c81975F9AE1753Fc559A",
-            "0x0Bc03983Da93021a374C964A22b73865220Ce962",
-            "0x74A868AC479EE145029bB80827BB77F7B7c441cB",
-            "0x7D60CfaF7c2cec210638A5e46E4000894830C034",
-            "0x2fcbD02d5B1D52FC78d4c02890D7f4f47a459c33",
-            "0x2238eDf33a72860cDbaec5F83ec246Df9e85c8E2",
-            "0x81Cda0aB38d8Bd0732123Eb0e36C0C566d35DADD",
-            "0xF7533CDCE5A2F7BF78B6fbf4B05f04F45D10140B",
-            "0xA7dE2e941c8818E51D1Fd84111d8F71dcafa6C3B",
-            "0xbede127c14407b9c345f5d7fae5782ab8eaa33f3",
-            "0x0E535b7D073a93646512cEa18fa7e650CC2b17C4",
-            "0x59b2fd348e4Ade84ffEfDaf5fcdDa7276c8C5041",
-            "0x4115708Fc8fe6bB392De2e0C21c2C81dA2222394",
-            "0x93Cba8445b13a05287bFf90D882cbcB514D617b7",
-            "0x12c8faEdD62cF0C5d4D742E57B98737a9a3F5E0f",
-            "0x70F1753a765C4df582FFA3B8d96AB492714E8992",
-            "0xa7ED6dB5761613CaE7CaCfAAE9Dca07a77809F9d",
-            "0x847a05C22c7508C674342A95356Adf9b3a0e0D57",
-            "0x19Ca61E672d1c6105f609418bfDC784F92F4Ecf0",
-            "0xAe3Dd11e5a7f99eD4cba2768D4095a55fbF7841B",
-            "0x00aDE38841AB8c6e236E232041e43B41d74B8B45",
-            "0x81cb9eA2d59414Ab13ec0567EFB09767Ddbe897a",
-            "0xfB79b6713fe214B8748ED7b0db1f93E4f1aC9d29"
-        ]
-    },
-    {
-        "name": "HaHa Wallet",
-        "type": "Infrastructure",
-        "logo": "https://pbs.twimg.com/profile_images/1954195620006346752/644sSCzE_400x400.jpg",
-        "website": "https://www.haha.me/",
-        "description": "Native wallet with ultra-fast transactions, exclusive rewards, and discounts.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xbd2C0dc6521CD25A8bb3943f50B5Eec7A9d9a8a2",
-            "0x4631F923C3c470061A97e008ED9c33DA4349612c",
-            "0xfFf4baDfe0EB9731F5593fE7CEd5B1209055E640",
-            "0xA01A2488Cbe09156da4a78fA46483556CE41710a"
-        ]
-    },
-    {
-        "name": "Hyperlane",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1671589406816313345/wGzRPeEf_400x400.jpg",
-        "website": "https://hyperlane.xyz",
-        "description": "GMP interoperability to bridge, issue, swap, and more",
-        "monad_exclusive": false,
-        "contracts": []
-    },
-    {
-        "name": "KINETK",
-        "type": "AI",
-        "logo": "https://pbs.twimg.com/profile_images/1947607859702673408/hpZ89aya_400x400.jpg",
-        "website": "https://www.kinetk.ai/",
-        "description": "KINETK is building the IP infrastructure layer for the next generation of digital creativity, unlocking attribution, protection, and capital for creators. Through the combination of proprietary invisible watermarking, agentic AI detection and tracking, and on-chain registration, KINETK is providing the tools that will underpin the future data models of the digital landscape.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xD057B63f5E69CF1B929b356b579Cba08D7688048"
-        ]
-    },
-    {
-        "name": "Kinic AI Memory Agent",
-        "type": "AI",
-        "logo": "https://cdn.prod.website-files.com/6712749157ea3bf4a781f309/671bbee00d9198b08a63cb40_kinic-logo.svg",
-        "website": "https://kinicmemory.com",
-        "description": "AI-powered memory system combining Kinic/Internet Computer for semantic storage with Monad blockchain for transparent metadata logging and audit trails. Features Claude AI integration for intelligent context-aware responses.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xEB5B78Fa81cFEA1a46D46B3a42814F5A68038548"
-        ]
-    },
-    {
-        "name": "Kintsu",
-        "type": "LST",
-        "logo": "https://pbs.twimg.com/profile_images/1984001421960704000/UpI70-s4_400x400.jpg",
-        "website": "https://kintsu.xyz",
-        "description": "Composable liquid staking protocol that powers decentralized validator curation, governed by the Kintsu DAO.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xA3227C5969757783154C60bF0bC1944180ed81B9",
-            "0xf16f96c342913575e46cff1bb827533c0b285138"
-        ]
-    },
-    {
-        "name": "Kodeus",
-        "type": "AI",
-        "logo": "https://arweave.net/MS-KY8qBeQ0KHJvez0HgkkrXCN48_ZnlUWrzIQJil2k",
-        "website": "https://kodeus.ai",
-        "description": "Kodeus is the Internet's Agent Layer where users create programmable and monetizable agents that act, settle and prove autonomously",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x3d3c1Db86989eD5196358eE03e2F1258EA183dCB",
-            "0xa0371d51C086f846Bd02c331DD31cc510645332e",
-            "0xa2c272C0D4fd83587ce3A4e81FA3Ad0eB9d63F9D"
-        ]
-    },
-    {
-        "name": "Kuru",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1950962142917619714/R7Cj_qk7_400x400.jpg",
-        "website": "https://kuru.io",
-        "description": "Kuru is the all-in-one trading hub for Monad. Trade any spot asset with our smart aggregator and trading terminal. Deploy liquidity on our hybrid AMM-orderbook. Launch a new token in seconds.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xb3e6778480b2E488385E8205eA05E20060B813cb",
-            "0x465D06d4521ae9Ce724E0c182Daad5D8a2Ff7040",
-            "0xd651346d7c789536ebf06dc72aE3C8502cd695CC",
-            "0x2A68ba1833cDf93fa9Da1EEbd7F46242aD8E90c5",
-            "0x974E61BBa9C4704E8Bcc1923fdC3527B41323FAA",
-            "0xe29309e308af3EE3B1a414E97c37A58509f27D1E"
-        ]
-    },
-    {
-        "name": "KyberSwap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1641706567014940672/UFuWgdxn_400x400.jpg",
-        "website": "https://kyberswap.com/",
-        "description": "KyberSwap is a decentralized trading solution that helps users find the best token swap rates by routing trades through multiple DEXs and other liquidity sources across multiple chains.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
-            "0xcab2FA2eeab7065B45CBcF6E3936dDE2506b4f6C",
-            "0x89C91686948C3Bc9A5bDF7A2A773ea71530a233e",
-            "0x4445520306c9C70952bDFEc28F3989f53d9f80C4"
-        ]
-    },
-    {
-        "name": "LFJ",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1852261646409809920/-ZwSUHqA_400x400.jpg",
-        "website": "https://lfj.gg/",
-        "description": "The most CRACKED fee machine in crypto. Ultrasound DLMM with hyper-efficient trade flow capture.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xb43120c4745967fa9b93E79C149E66B0f2D6Fe0c",
-            "0x18556DA13313f3532c54711497A8FedAC273220E",
-            "0x9A550a522BBaDFB69019b0432800Ed17855A51C3",
-            "0x3A8E1Be95467690F7C592B596e42d11b3710c633",
-            "0x6124086B90AB910038E607aa1BDD67b284C31c98",
-            "0xA5c68C9E55Dde3505e60c4B5eAe411e2977dfB35",
-            "0x7ac3Dd4B5A3F7013116D8a28f0579a678282EA5c",
-            "0xDbeeB3FB3e864e490e71b1d5c86c3de683cA4626",
-            "0x45A62B090DF48243F12A21897e7ed91863E2c86b",
-            "0xF8155BcA49576B54018311C6129bdA088605B88b",
-            "0xF780668669C193B5D2Cf22B8420473fA1E3Ee3D1",
-            "0xe32D45C2B1c17a0fE0De76f1ebFA7c44B7810034",
-            "0x4faCe5b0EF2757Ceb9151D14C036A1135931C70E",
-            "0xf57B8a91F775B01d53450D7Cb4D2A99Ba989fd19",
-            "0xe70d21aD211DB6DCD3f54B9804A1b64BB21b17B1",
-            "0x371c7ec6d8039ff7933a2aa28eb827ffe1f52f07"
-        ]
-    },
-    {
-        "name": "LayerZero",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1779646801605242880/FrFssPAQ_400x400.jpg",
-        "website": "https://layerzero.network",
-        "description": "Powering the Chain-Agnostic Future",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
-            "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
-            "0x4208D6E27538189bB48E603D6123A94b8Abe0A0b",
-            "0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842",
-            "0xC39161c743D0307EB9BCc9FEF03eeb9Dc4802de7",
-            "0xe1844c5D63a9543023008D332Bd3d2e6f1FE1043",
-            "0x41Bdb4aa4A63a5b2Efc531858d3118392B1A1C3d",
-            "0xc1ce56b2099ca68720592583c7984cab4b6d7e7a"
-        ]
-    },
-    {
-        "name": "LeverUp",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1963940143171346433/mefOgn9M_400x400.jpg",
-        "website": "https://leverup.xyz",
-        "description": "LeverUp is a next-gen perps DEX with LP-free trading, deep liquidity, and up to 1001x leverage.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xea1b8E4aB7f14F7dCA68c5B214303B13078FC5ec",
-            "0xFD44B35139Ae53FFF7d8F2A9869c503D987f00d1",
-            "0x91b81bfbe3A747230F0529Aa28d8b2Bc898E6D56",
-            "0x135951057cfcccA7E8ef87ee41318D670f723F68",
-            "0xbF52cED429C3901AfA4BBF25849269eF7A4ad105"
-        ]
-    },
-    {
-        "name": "Levr Bet",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1836024387042004992/YKdDMkOG_400x400.jpg",
-        "website": "https://www.levr.bet/",
-        "description": "Decentralized Leveraged Sports Betting",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8e334460192926576ccD04271190c9E9e5916560"
-        ]
-    },
-    {
-        "name": "Li.Fi",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1940673908946120704/ZkHt9ssN_400x400.png",
-        "website": "https://li.fi/",
-        "description": "One API for seamless swaps, bridging and Zaps across EVM and Solana.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37"
-        ]
-    },
-    {
-        "name": "M0narch",
-        "type": "Gaming",
-        "logo": "https://m0narch.xyz/logo.jpg",
-        "website": "https://m0narch.xyz",
-        "description": "M0narch is provably fair, fully on\u2011chain iGaming platform",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x5B159027C1BcFDADd11CB5b44519251DbADb3749",
-            "0x266b1540d35DB5f64569Fe2d7db79EeC2ACF67dB",
-            "0x79575d8787b184841fD9eB28AAee2971646259cE",
-            "0xbB053a8CE778D8492Db5079aC36FfA99Bde92aBc",
-            "0x446012177a183adc281Df23987c21B0F83Fb7e97"
-        ]
-    },
-    {
-        "name": "LootGO",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1947490514921488384/TLSJg7Z5_400x400.jpg",
-        "website": "https://lootgo.app",
-        "description": "LootGO is a walk-to-earn mobile app that turns your steps into a real-world crypto treasure hunt. Think: Pok\u00e9mon GO, but with crypto rewards.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x3E1fC8371bf6dCEFfd829ae2134005a4AE890b71"
-        ]
-    },
-    {
-        "name": "LumiterraGame",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1667436896480563200/8YPmbLbv_400x400.png",
-        "website": "https://lumiterra.net/",
-        "description": "Lumiterra is an open-world game where you team up with an AI smart-companion that learns your playstyle, helps you win battles, farm faster, and explore smarter",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x4bd7aB4f4251f6A20E8c64D24F3A2f89F47D80B9",
-            "0x8f28E18039c37cdB4389E6dcb8703966fb9480A8"
-        ]
-    },
-    {
-        "name": "Mace",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1876861581763764224/3Z3F9Cef_400x400.jpg",
-        "website": "https://www.mace.ag/",
-        "description": "The smartest DEX aggregator on Monad",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6F05a0746a8CB5c7DE5aF1568C8d020DBB521B23",
-            "0x70ca11a8bb062EF86e6E662b58aE3cAEeF1d66e5",
-            "0x60672942Dd9BEAf2D4980892A1B8001B5178149f",
-            "0x8A64d063Dc534a160914da4Dc86804be5e8DE98b",
-            "0x73590e38F40F799eDb3AfE3142c0Ea891F393D9D",
-            "0x0E89C6d18933E2dA3a5C56B0727113B2247AC847",
-            "0x59966aDd989Bb2b8A528B796a81FB7e593072529",
-            "0xb346fbd2Ba963a1C3B00946c733e9f0d5CE7AEeC",
-            "0xaA318069cEe0E16E25B8aA34C27Ac20C4DE16fC2",
-            "0x39C361d267853A43f4e6237291CeA0701C426aBe",
-            "0x7D120C4FCcBd620b398E04f9147271cF5cAC587C",
-            "0xA24bE4225DdA623E4Db49Ed12c80AaE583447482",
-            "0x42A3ED3010D38daB622b9e135df724AB4a813cd7",
-            "0xC1d16c871d816Cb2400243dC7A61ed4E9137FbEb",
-            "0xC6B6b9E8eB8b3cf2Cecd8Ff536A9E1599D8Ab426",
-            "0x9D282092C60303BA8Fc219501CfEdAFAFa290A64",
-            "0x5C968a45404e55Ffa5DA393fe7db96f244792707",
-            "0x057F554fe1558D2910e5e0865d9177E8EBB60197"
-        ]
-    },
-    {
-        "name": "Madhouse",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1978014535148535808/LYuLF9u0_400x400.jpg",
-        "website": "https://madhouse.ag/",
-        "description": "Experience lightning-fast 10,000 tps on Monad with Madhouse aggregator. Trade with speed, high liquidity, and madness.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6017684Bea9Cb6e9874fC6DBA4438271eBF9F5DA"
-        ]
-    },
-    {
-        "name": "Magma",
-        "type": "LST",
-        "logo": "https://pbs.twimg.com/profile_images/1798840544887787520/OWxSEpYX_400x400.jpg",
-        "website": "https://www.magmastaking.xyz/",
-        "description": "Native liquid staking and MEV, powered by the fastest block engine in crypto.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081"
-        ]
-    },
-    {
-        "name": "Matcha",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1936106079877844992/t_kZCRae_400x400.jpg",
-        "website": "https://matcha.xyz/",
-        "description": "Matcha provides optimal trade execution and helps you discover new tokens by aggregating hundreds of DEXs and private market makers. Get complete token coverage, gasless swaps, and deep liquidity on Monad and 15 other chains with unbeatable pricing on any token pair.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x0000000000001fF3684f28c67538d4D072C22734",
-            "0x478cF28Fd1Ba92a6afd04F44b05833F6dF7f1486",
-            "0xFB36B62145A4B272bc804e5E1b41ddbf4BFF4CF4",
-            "0xb2376d1183829f444e0ffE9EF1FFaf1b483B84F3",
-            "0xb40e9939bb598C38665A5C99c68020EEB8Cf49FB"
-        ]
-    },
-    {
-        "name": "Mayan",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1992936326153244672/Qqu1LGXS_400x400.jpg",
-        "website": "https://mayan.finance/",
-        "description": "Mayan is a lightning-fast, intent-based cross-chain swap protocol that makes transfers seamless, instant, and cost-effective. Move any asset directly into Monad through our simple swap interface or integrate Mayan\u2019s SDK and widget for seamless cross-chain liquidity.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x337685fdaB40D39bd02028545a4FfA7D287cC3E2",
-            "0xC1062b7C5Dc8E4b1Df9F200fe360cDc0eD6e7741",
-            "0x598400bA0d8BA9C3b57ad424A68183f1D17c7e56"
-        ]
-    },
-    {
-        "name": "Mintpad",
-        "type": "NFT",
-        "logo": "https://pbs.twimg.com/profile_images/1780703842142941184/bcu1af6z_400x400.jpg",
-        "website": "https://mintpad.co/",
-        "description": "Something like this ok - Mintpad is the easiest way to launch NFTs on any EVM chain \u2014 completely free for creators. Upload your art, customize your mint page, and deploy fully-owned smart contracts in minutes with zero coding required. Mintpad handles all the technical heavy lifting so you can focus on creating and building your community. It\u2019s the fastest, simplest, and most accessible way for anyone to launch an NFT collection.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xaaae0243007AA3000000d8e8bEeF0a944A0d3900"
-        ]
-    },
-    {
-        "name": "Mona Trading Bot",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1954134808667545600/W4Af_hDl_400x400.jpg",
-        "website": "https://t.me/monatradebot",
-        "description": "Fastest trading bot built on Monad",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x27A6c2E8aE9E7f96040394a1F8fE2A202cE0E599",
-            "0x7e75D7EB235703D8AcbD71382bF2F344fB23aB5b",
-            "0x95dEf69A01962f0Cb24e2C5DAA1Fa5126Beea95D",
-            "0x50aDc49F643F06888A8950dD172Ae48221e49a38",
-            "0x09ec7D8D3065097D5859539ED4590Dd76c0C77e0"
-        ]
-    },
-    {
-        "name": "Monorail",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1964025665105137664/rny-s1Dq_400x400.jpg",
-        "website": "https://monorail.xyz",
-        "description": "The best swap aggregator on Monad",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xa68a7f0601effdc65c64d9c47ca1b18d96b4352c"
-        ]
-    },
-    {
-        "name": "Mu Protocol",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1834816886292508672/VDkHAG2v_400x400.jpg",
-        "website": "https://mudigital.net/",
-        "description": "The Mu Digital protocol provides DeFi users with access to a diversified pool of USD-denominated, principal-protected RWAs through a dual token structure comprising of a safe yield token and a high yield token.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x4917a5ec9fCb5e10f47CBB197aBe6aB63be81fE8",
-            "0x336D414754967C6682B5A665C7DAF6F1409E63e8",
-            "0x9c82eB49B51F7Dc61e22Ff347931CA32aDc6cd90",
-            "0x00A927d9d8af27d06C4e2C3abb5b88b0E1766470",
-            "0x7B14860eCd88fb65A22A1d259D1248BF199FB47f",
-            "0xeF1776eD00e8f9Fe783e269d10676C7820465461",
-            "0xF3CDC00ccA19F336b1c1B4Bd684A949124a93Ea7",
-            "0xB55F4F4BBB466f9C022d3edF4B584c30Eb624113",
-            "0x8B9670C5E4D9F1C14f1F9fe625Dd099924aD4D4f",
-            "0x74AE87E5CE997B73Acfac85a3CE5570475D6B46B",
-            "0xe64730de04aeAf8d38925825D77D7a4c00340c89",
-            "0xe5f8Ec544310D5ae79DA0F921D01ce80fFD528eB",
-            "0x35F73a069554bb11d73307564265451b88B3e3b6",
-            "0x345E3ff3c551D1ad33A7294f405084b9863B9aae",
-            "0x3E0Ff06afCF1011c91A5063ca57f2Fcc54f7E862",
-            "0xd91C46C66c56e391f562885B1CF279b838863eda",
-            "0x319817781134B450B3A7C672243Cc701BFCaB44E",
-            "0xEDB2d57678440AD5bBE2213695B2ABEB754b72F7",
-            "0x9d839E0A6a86b05643b4811dE06ef09985EbBaef",
-            "0x0b4c9Dd5A3ecc14225d9b895716a65e4A7aD3fEc",
-            "0x7c28385Ee6cAd71a4C7F747f302582170a7B93BE",
-            "0xD4dF076285F36b8C996Fc5f2DC1f886f23a64229"
-        ]
-    },
-    {
-        "name": "NFTs2Me",
-        "type": "NFT",
-        "logo": "https://pbs.twimg.com/profile_images/1626191411384053761/NoRNmw9L_400x400.png",
-        "website": "https://nfts2me.com/",
-        "description": "NFTs2Me is a user-friendly comprehensive platform to create, deploy and manage your NFT collection on Monad, 100% free.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x00000000001594C61dD8a6804da9AB58eD2483ce"
-        ]
-    },
-    {
-        "name": "Nad.fun",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1827607782356619264/Owr-840k_400x400.jpg",
-        "website": "https://nad.fun",
-        "description": "Launch, trade and predict on Monad",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xAd8887348E5d5d479156c851F4F4778e83a1DFE3",
-            "0x65fDa572628c1D3F55B9e9E66e6e8a61c53cfF7c",
-            "0x3Be9198208c198e2a4dab9A575764C8468DC83c6",
-            "0x4ac5Fd82B91A10de7f91343DDCca7a2541d3F509",
-            "0x46895ee48Fb1D750A81562fd6019B37F21d7FD52",
-            "0x42e75B4B96d7000E7Da1e0c729Cec8d2049B9731",
-            "0xb0bAaCE23aC7cbd25211134a0B47ad70a9D42FA4",
-            "0x6F6B8F1a20703309951a5127c45B49b1CD981A22",
-            "0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE",
-            "0xAebe5522749b65eaE7b2A35c593145CC3128b515",
-            "0xCD68F7c0668B72Ab943E09Ff4Dbf53Da64b8a8c2",
-            "0x095ACd3d26DD09c8E26Ab864c8717a39fE61F320",
-            "0x0B79d71AE99528D1dB24A4148b5f4F865cc2b137",
-            "0xD5eE94894f3C86952AF792e1a03B1699c08b8c73",
-            "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea",
-            "0x7f64ccFeb3E3Afd7691ea0ef404E947786cefae8"
-        ]
-    },
-    {
-        "name": "Nar.bet",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1988147564227764224/MnPg-Spe_400x400.jpg",
-        "website": "https://nar.bet",
-        "description": "Nar.Bet is a derivative project of Narwhal Finance, built exclusively on Monad, delivering the first fully on-chain, provably fair betting experience that is gamified, social, and community-driven.",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x71dc4a726C92E6bf506F2Afc2Cee8B63A89B29EC",
-            "0xa7f902847a16F1CDbF043c0653865D40e6695de5",
-            "0xDA18dC7bb27Ca2056Fa3cA3da3973218Dc18F8e3",
-            "0x8baecE06d825d36b52cb588960aE707d6C76a54C",
-            "0xe3C0B41413Bc9913E0ace43a64637EF6C4e39F97",
-            "0x1CE656bD09a59A59513c4460220031d49038739e",
-            "0xf970b3C6A1bd7745A07B317543EA999e4E98666c",
-            "0x681D2C159EE77f660F5081a3c193fb9613b624C0",
-            "0x39AA4ECB48c52A018B2a1A700B89C4912FC39967",
-            "0xBEAaFcc7648354a0722350378bF2A295B9b946A8",
-            "0xbB1b4eE5D22ca19faa5aA9A55Caf4abAEd14607B",
-            "0x11B83A467AbFF4c466294af94B99ACEF3D85929d",
-            "0xFfbfB423dE2a5305004aeA3bdF6bD4917E87A962",
-            "0xdE5C871Fb0626562E9Acecc3c5b0EB12C298d8BC",
-            "0xEeBB73F7B52cD86ABc76e1fce2b5a38A684BCacc",
-            "0x0badb8f24327074CF94d6398E1B722e201c0BBf0",
-            "0x33F906D6c6aA65fb3055f2028dc394033C3310F3",
-            "0xBF3727f9aee1140870AF3303fba52537536F8e5D",
-            "0x49a3F93deDca36c7FA5Af695e89eEa0f03a1A11a",
-            "0xf485d6F84537bdf3A2096508652F9a6876975A8C",
-            "0xbF34070fEEF2063277626904F7BF736D70826604",
-            "0xb0279eB0cD894f9964c1945D9543FD6fc5C929fE",
-            "0xB3aFCc826F9dBF2A1a9F78a2ddDCD12517589267",
-            "0xAC55756556df38D9Be82AaDd31ac3849EC7826E2"
-        ]
-    },
-    {
-        "name": "Narwhal Finance",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1988146944473182208/89x23JI6_400x400.jpg",
-        "website": "https://narwhal.finance/",
-        "description": "Narwhal offers a distinctive trading experience with synthetic leverage and no order books or liquidity for each pair. The PnL calculation occurs in smart contracts and is settled against NLP for a secure, transparent process. This streamlines trading and provides a unique opportunity for leverage-based trading.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x3556d16519e3407AD43d5d7b3011bB095553d77a",
-            "0xfbc1cf329aD241352e777aB7BC17962452B87949",
-            "0x5c39f9739c123e64535F6250b256964Bc20c52f1",
-            "0xE22FB1f1bB003759FAcED645458B8b8ee262828d",
-            "0xb412A5d72c203Df308624e435659c9F70b6960aA"
-        ]
-    },
-    {
-        "name": "Neverland",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1993662956098232320/UcnsahQh_400x400.jpg",
-        "website": "https://neverland.money",
-        "description": "Neverland is a Monad-native decentralized lending protocol built on the Aave V3 framework, reimagining DeFi incentives through self-repaying loans, flexible NFT-based veToken governance, and automated yield strategies. It redistributes 100% of protocol revenue back to the community through governance-directed rewards, liquidity incentives, and deflationary buybacks and burns.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x73A78AFa04b629e22db3BEC357bfc4a8B4f149DF",
-            "0x80F00661b13CC5F6ccd3885bE7b4C9c67545D585",
-            "0xe3B56AAD3c21531055f39e73A51E8ff29DAAD049",
-            "0x49D75170F55C964dfdd6726c74fdEDEe75553A0f",
-            "0xD0CCDe10CAcd12f1c839Db6400B82a82ab90fa9B",
-            "0xfd0b6b6F736376F7B99ee989c749007c7757fDba",
-            "0x193672B2454850EE247435E365a87F7cb857a0f7",
-            "0x67B7178105D3715214E1F187C20CDd20B708F443",
-            "0xE7D17A88C66b4ED0b73872937cdC5e081C118DcD",
-            "0xE0B05346Fa8F57C2C634Ee1D53Ace20806858c01",
-            "0xc8a6A884B47ca0699A9dd76d5B8d1D3D21A8d94b",
-            "0x4de9DB60667Eb48A1Bf5c556BbA79058c44e34c2",
-            "0x44d2575191306Da86C488Bf86872Ca6D35489E4A",
-            "0x427B9008A254799aA3ac1d5Cc1DC2920dA3ad3Cf",
-            "0x4AD738afaC73f32F1e5F1898BCA150d4A52C88Db",
-            "0xdcF1Dcb529fE2C61bf8Bbb10eB8b5ae843882dC5",
-            "0x4c505f18C39Ef5881bCb5eBFBDd89E607ea2185d",
-            "0x09bD1E4bc6F035D5025D0e86a9b24a7fC9F1125B",
-            "0xb00E2D557cFCF73A3c6D9Fe98332290fac7546e4",
-            "0x9B4528918159e1ae937740051Fb69bcD4E164cc3",
-            "0x94bbA11004B9877d13bb5E1aE29319b6f7bDEdD4",
-            "0x395118096F0Ef19D7958Ad8538ecee9685B94eb2",
-            "0xbeA2124aE6d8225c491A85db16c419dcDC62159d",
-            "0xA02c3E9d0b9deC0A7F53908742af141Af4EF45b5",
-            "0x936C7E76905c83Edc12F8A5ca993a6609D8bBAA2",
-            "0xD0fd2Cf7F6CEff4F96B1161F5E995D5843326154",
-            "0x81b19837295a2b4b1f6E0B2eaA239999294374E4",
-            "0x3acA285b9F57832fF55f1e6835966890845c1526",
-            "0x38648958836eA88b368b4ac23b86Ad44B0fe7508",
-            "0x7491E87eed26418ff67422169a7608E67d691978",
-            "0xb26FB5e35f6527d6f878F7784EA71774595B249C",
-            "0x8911Db480C1c0c1E06f17C2Bc76b26D861e40D47",
-            "0x81242ADa455D766b5032EB4abf9baEaA49077450",
-            "0x0733e79171dd5A5E8aF41E387c6299bCfE6a7e55",
-            "0x800409dBd7157813BB76501c30e04596Cc478f25",
-            "0xAD96C3dffCD6374294e2573A7fBBA96097CC8d7c",
-            "0x4522144959Afee1CAe8aa553b6a5cB81E111A4DA",
-            "0xBB4738D05AD1b3Da57a4881baE62Ce9bb1eEeD6C",
-            "0x3875cdF0d2B4445B763B7FCAC5d28Db2ad6D30e7",
-            "0x57ea245cCbFAb074baBb9d01d1F0c60525E52cec",
-            "0x6aD1EcdA817ECB7696D21f6e600C7ec44AcFB1e6",
-            "0x394060Ee4cf4781F5ff6bCf471426D97A11977fA",
-            "0xff20ac10eb808B1e31F5CfCa58D80eDE2Ba71c43",
-            "0x1df0F25344D29F541a53502a96DfeD3066D40b0A",
-            "0x794CCdb375Ab08C340528a71Ba433a9016c657A5",
-            "0x49f745b5265b6CA695E60e89dc50FD36edD252AB",
-            "0xc9Fe3Db9b14A538FaB2eeBa33a8FeaB6ED7DdCeb",
-            "0xe82f2fa836BC5DB42a36C66027c0113BcAA28143",
-            "0x95AF995C9dcB1b6cFFEe6d81631dab5527884370",
-            "0x6400650cED1eD7179143D40b4431c3cC8c068D90",
-            "0xc91BA13910b358E0De6510D4e2F3AFDaf6395538",
-            "0xc8B7b87EB4a4B404a421bD3a1491a689A0be8611"
-        ]
-    },
-    {
-        "name": "OctoSwap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1881835000024231936/Fb3P06s-_400x400.jpg",
-        "website": "https://octo.exchange/",
-        "description": " OctoSwap unites the strengths of both classic and concentrated AMMs with an advanced smart router, making it the premier liquidity hub on Monad for efficient liquidity and execution. ",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xCe104732685B9D7b2F07A09d828F6b19786cdA32",
-            "0x60fd5Aa15Debd5ffdEfB5129FD9FD8A34d80d608",
-            "0x30Db57A29ACf3641dfc3885AF2e5f1F5A408D9CB",
-            "0xBfd2cf709A17c4eEE8DaaF3B96E134408881259e",
-            "0xF27Ba2b4ee5580Cb2A14FDF98CB981FF0ae149F4",
-            "0x2Ff18d8Ca8447DB19392AA3e27DCB640CEe83882",
-            "0x16eb676BbBe51EB6E4E9DDF57BfBEe0537aA4d7B",
-            "0x241BF19641839b249E8174Bd22FACd3d3ac0642A"
-        ]
-    },
-    {
-        "name": "OrbiterFinance",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1880886737221664768/_uBH9pgt_400x400.jpg",
-        "website": "https://orbiter.finance",
-        "description": "Bridge and swap crypto assets quickly, affordably, and securely across Arbitrum, Base, Optimism, Solana, BNB Chain, Polygon, Ethereum, and more blockchain ecosystems with Orbiter.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x70f6060fc8b01b56869feba8361df468f98c2900"
-        ]
-    },
-    {
-        "name": "Orochi",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1877208842834161666/DosXGKCB_400x400.jpg",
-        "website": "https://orochi.network/",
-        "description": "Orochi Network is a Verifiable Data Infrastructure designed to ensure data integrity and privacy through advanced cryptographic techniques.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x78291455bf33aA5437f9D69Ff63E0B1C09833429"
-        ]
-    },
-    {
-        "name": "PancakeSwap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1992213522940571648/yEcd7vsj_400x400.jpg",
-        "website": "https://pancakeswap.finance/?chain=monad",
-        "description": "Trade and earn crypto on the all-in-one decentralized exchange. Enjoy low fees, high liquidity, and a user-friendly interface.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x02a84c1b3BBD7401a5f7fa98a384EBC70bB5749E",
-            "0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9",
-            "0x41ff9AA7e16B8B1a8a8dc4f0eFacd93D02d071c9",
-            "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865",
-            "0x1b81D678ffb9C0263b24A97847620C99d213eB14",
-            "0xb099b459887bC759dBF0293E12D3DFcD0C456cff",
-            "0x46A15B0b27311cedF172AB29E4f4766fbE7F4364",
-            "0xac1cE734566f390A94b00eb9bf561c2625BF44ea",
-            "0x3095eC7D29b588283baB3184fae4dECd54D5D811",
-            "0xbC203d7f83677c7ed3F7acEc959963E7F4ECC5C2",
-            "0x9a489505a00cE272eAa5e07Dba6491314CaE3796",
-            "0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997",
-            "0x21114915Ac6d5A2e156931e20B20b038dEd0Be7C",
-            "0x77b482D9A4E391d682C857C630B8d869FdeE5c44",
-            "0x4c650FB471fe4e0f476fD3437C3411B1122c4e3B",
-            "0xfcB76dfDf9c79AE5d334C0E1901449c8A893DF22"
-        ]
-    },
-    {
-        "name": "Peridot",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1967990362242203649/oELnCnhK_400x400.jpg",
-        "website": "https://peridot.finance",
-        "description": "Peridot allows users to earn interest on your crypto and borrow funds without selling, all with smart, fair rates across multiple blockchains.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x96650BebC549456F253974c11Fc6cBE28172A2d2",
-            "0x42D5B37CD3682eDD0a3dBb242C579bDCB108f47C",
-            "0x81C0533c8132Bc20c3A53f599925AB01c7dA2B3A",
-            "0x6D208789f0a978aF789A3C8Ba515749598940716",
-            "0x1FB287E1c4F7B4c6b511f4d190523814593Ad84e"
-        ]
-    },
-    {
-        "name": "PingMe",
-        "type": "Payments",
-        "logo": "https://pbs.twimg.com/profile_images/1985754835460005888/UiqxXJjA_400x400.jpg",
-        "website": "https://www.pingme.xyz",
-        "description": "Making stablecoin payment as simple as sending a message",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x3de0E31A0a9d885bF98ea1512188e06F70D507B2",
-            "0x2a217B43b138e36979f59999776585ed6Bb27542",
-            "0x32F62bDC2BE3E1B1C0265143831155253cd5A248"
-        ]
-    },
-    {
-        "name": "Pingu Exchange",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1969166356009373696/TQYJNyzA_400x400.png",
-        "website": "https://pingu.exchange/",
-        "description": "A perps protocol for trading crypto and real-world assets with leverage.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x605AD21A6A9328d74fA88AA80F23dbD4e746b2fD",
-            "0x4F6e71a81a72Fbd33C599596A7E3e28Aa4b44Ebb",
-            "0x631c6E0d5ae2E1F6a39871a9BE97F1D9d43D1C83",
-            "0x379A14208c15e99177b6A2003B77F38f80D66a2f",
-            "0xE0FfD61De51Ce62D47845c5e6F10c35e8807224d",
-            "0x576d51fB872065DC4Af6f83902fd4078eBCc2f03",
-            "0xe5CdF1b3b36b9799B33E5C6f8C4c8B03848C6470",
-            "0xDD9Bb855fcD8bc3F45b54B9C1F9dE43Dd2DFf06B",
-            "0xCB30DFf8515d4170BBf1fd0Ff01CB21F9ACc4caF",
-            "0x06FC8B836F78A2C95416d33028452f9C95AAc6b4",
-            "0x66700b04bD1a912996fdB90f05c1B0965Fef1b62",
-            "0x1B313E19Df0B33880e99f38AC58e6BbdCC5B1810",
-            "0xD849497f08180d3f1a79397EF8ae4DBD05EC1a5c",
-            "0xD7071C24f765Ca1ad21FF8E9d89ad45845Af64DF",
-            "0xeE6A587C06e02f330C00EA3E7c102d9b1d8a52f3",
-            "0xb1744C2e2B9b34630551338568698368489AEB7f",
-            "0x3d7ec93875B6a6f0A5102fE29f887ee6E751b12F",
-            "0x75F2948bfF7D6D6bb6133cc5FE3c710656c2A939",
-            "0xBfC60682970fd08E2e4eEa96f8B7b6BFa25EAb53",
-            "0xD53b51aE4216B80422216269Edf064E9DE89749b",
-            "0xCf410B10C0f30948033e47b7209CC026054E9F18",
-            "0xe199e871fC628488d6cd1b2d192Ed51Dc8f5b88F",
-            "0xDfD770c6ca5F690289Ddf6a173025719C07996c4",
-            "0x15E5E522a44B562f3c87da77c87eC858F62d221E",
-            "0x133f72734a185ff821705af80D57B8823CA8bC8e",
-            "0x99903470cc631D01F271340C94E224262168ED95",
-            "0xA2426cD97583939E79Cfc12aC6E9121e37D0904d"
-        ]
-    },
-    {
-        "name": "PinotFinance",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1943235355815055360/aCWwgtyJ_400x400.jpg",
-        "website": "https://pinot.finance",
-        "description": "Advanced liquidity and trading hub for Monad powered by real-time voting system.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x0D96571886FE0CbcaFef3109e8B569c7498Ed3fc",
-            "0x89975e0FA4e663BB3D52cE699bDC792aD24C7273",
-            "0x3cBe70c025F045ACACFBeC5119D70b6ebD076b9a",
-            "0x7F00f30D518737A6De6E2A4c9Da39D356ca3a737",
-            "0xA217276C368C9f548F9838863904bE3f9f0D9844",
-            "0x14B8190E024F10A4F0ac0d118aF3F5807FA3fe12",
-            "0x7716F310d62Aee3d009fd94067c627fe7E2f2aA9",
-            "0xb8058cDbC6CdC4b0aA0Aa00A7Ecf7CAAF1441392",
-            "0x252b9C1A6C9867a514ea70fe9bBB23621ACc1a50",
-            "0x22e3d8acB2b32F138018732B6f034e05A46E42f8",
-            "0xfb72484A019F2458B8B609D9230f320f5371A3E3",
-            "0xbC3e14cdbFDd8bb58D1B9A7AA20C316E6b32643D",
-            "0xA8f00b0Df5D4aDa95Fc89E8c389819594Ef45720",
-            "0x82A70cAbe732542996A57455AFfec578b4061322",
-            "0x452146eb925F089A5999976674f40692aD44549C",
-            "0x0a99443B8D303D443BD86186c68C78f3A55c5487",
-            "0xCae374853E8D37C2C8FC6FeA770629054c391756",
-            "0xd7f63BBb5F866258Eb9b9112b6A940D35dbaeb4f"
-        ]
-    },
-    {
-        "name": "Poply",
-        "type": "NFT",
-        "logo": "https://pbs.twimg.com/profile_images/1960818622537814016/3qEMjXr4_400x400.jpg",
-        "website": "https://poply.xyz/",
-        "description": "Community-based NFT Marketplace & Launchpad, built natively on Monad. Launch Freely, Trade Seamlessly.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x81389AEcADcff4b8ae1391d3DceC9a21dE51694C",
-            "0x35a9EaF67C2C6276c8Edf083D5b42eC36214eBd3"
-        ]
-    },
-    {
-        "name": "Primus Token Distribution Platform",
-        "type": "Infrastructure",
-        "logo": "https://avatars.githubusercontent.com/u/111639885?s=200&v=4",
-        "website": "https://pay.primuslabs.xyz",
-        "description": "zkTLS enables rule-based token distribution without ever needing to know the recipient\u2019s wallet address.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xa2e0700a269Be3158c81E4739518b324d4398588",
-            "0x50bd377EB8D4236Bb587AB3FB1eeafd888AEeC58"
-        ]
-    },
-    {
-        "name": "Puffer",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1874641749865607169/08edgUL-_400x400.jpg",
-        "website": "https://www.puffer.fi/",
-        "description": "Puffer is a decentralized native liquid restaking protocol (nLRP) built on Eigenlayer.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x37D6382B6889cCeF8d6871A8b60E667115eDDBcF"
-        ]
-    },
-    {
-        "name": "Purps",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1950588400614166528/MUPvD19X_400x400.png",
-        "website": "http://app.purps.xyz/",
-        "description": "Designed to provide deep liquidity and seamless trading, PURPS enables efficient asset swaps while also serving as an incubator for emerging projects, helping them access liquidity through its powerful launchpad. By combining advanced liquidity mechanisms with a streamlined IDO platform, PURPS ensures that both traders and startups can thrive in the Monad DeFi landscape.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xAfE4d3eB898591ACe6285176b26f0F5BEb894447",
-            "0x22aDf91b491abc7a50895Cd5c5c194EcCC93f5E2",
-            "0x17B4b5F99ec25aAaA644107f86A7756212D4D026"
-        ]
-    },
-    {
-        "name": "Pyth",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1948404937857122304/XPBCFnR5_400x400.jpg",
-        "website": "https://pyth.network",
-        "description": "The price layer of the global financial market.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x2880aB155794e7179c9eE2e38200202908C17B43",
-            "0xD458261E832415CFd3BAE5E416FdF3230ce6F134"
-        ]
-    },
-    {
-        "name": "Rango",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1876978070885695490/lNfhcNta_400x400.png",
-        "website": "https://rango.exchange/",
-        "description": "Rango offers smart routing over DEXs, DEX aggregators, bridges and cross-chain protocols to provides cross-chain swaps, interoperability and message passing",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x69460570c93f9DE5E2edbC3052bf10125f0Ca22d"
-        ]
-    },
-    {
-        "name": "Redstone",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1875180006185246720/rofJl5Xq_400x400.png",
-        "website": "https://redstone.finance/",
-        "description": "RedStone is the fastest-growing Modular Oracle, specializing in yield-bearing collateral for lending markets, such as LSTs, LRTs and BTCFi.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xc44be6D00307c3565FDf753e852Fc003036cBc13",
-            "0xED2B1ca5D7E246f615c2291De309643D41FeC97e",
-            "0x1C9582E87eD6E99bc23EC0e6Eb52eE9d7C0D6bcd",
-            "0x7A9b672fc20b5C89D6774514052b3e0899E5E263",
-            "0x90196F6D52fce394C79D1614265d36D3F0033Ccf",
-            "0x1b0FDa12D125B864756Bbf191ad20eaB10915a6F",
-            "0x0bE6929FD4ad87347e97A525DB6ac8E884FCDCeC",
-            "0x98ECE0D516f891a35278E3186772fb1545b274eB",
-            "0x7A532B1B204409472cB92cd07c8B0BB09DD2F520",
-            "0xD3A0C347b07Fd45F41270D557089B389Fa735C3d",
-            "0xC0FC9416b5c3737E13507f4bAD58cFc016779C84",
-            "0xB3C5BE567817F127412d1758048b376D4D35ec51",
-            "0x6e7407fcd5021e3FE5f75959575b20C85231562d",
-            "0xFFD1339908E0deBE2416E03df0843B896b8944Fe",
-            "0xAd1A270a3F7FF685B90445d9da3EE7Eb22F8A1Ec",
-            "0xB144836c17C5d613Aa471f0BB9B79B55288c2C03",
-            "0x096073133355F874A7D0a857Ffac314dda4e0551",
-            "0x5577797e21FBbB7458f500fa80770D80AAE39bca",
-            "0xa79F7363FCa5118B4141eCeff6dd2A83d5047344",
-            "0xE77456457619ad1948336FBaBC3883cB965b50D1",
-            "0x61669df14B681010A5cfaefc4688Cf9e079ddE5D",
-            "0x63Bb491346fCC8695244D811F0c3501E6C2e8d25",
-            "0xD1136a8C1E5a8Ff204d6875b51158b5Ef1858f60",
-            "0x8C9f39f0D08EE284a4Fe0198524fE7C28630CEAb"
-        ]
-    },
-    {
-        "name": "Rug Rumble",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1988770949446168576/d9Laekir_400x400.jpg",
-        "website": "https://rugrumble.xyz/",
-        "description": "Rug Rumble is a provably fair gaming platform. The Run to a 100x has begun!",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xA33FCf1F510fF1365a7667e3328d042B7d559B8a"
-        ]
-    },
-    {
-        "name": "Sablier",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1163480930910199809/nlJtmWT1_400x400.jpg",
-        "website": "https://sablier.com",
-        "description": "Onchain token distribution. Handle your token vesting, payroll, airdrops, grants, and more with the Sablier Protocol.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xf51BB8bd1cfc7C890dB68c39dCCA67CAd7810Ce4",
-            "0xa0A1aC47260B95D334763473B868117EF7343aA0",
-            "0x1feB172238638897B13b69C65feB508a0a96b35D",
-            "0x619E7f9832522EDeBd883482Cd3d84653A050725",
-            "0x4FCACf614E456728CaEa87f475bd78EC3550E20B",
-            "0xaB15e653cD3bBCe7B7412f81056a450BC0f2e7B9",
-            "0x7DcAB43465c1EbDA92133c92262a6c55394dD69e",
-            "0xfA2Bf3EDdEfE67631BfFA5C53b621A9C6BEbc9C3",
-            "0xCdCc46A7759dE01271E533BBC3b0F32899545a76",
-            "0x0340a829b6dC3aDF7710a5bAF1970914af4977f5",
-            "0x003F5393F4836f710d492AD98D89F5BFCCF1C962"
-        ]
-    },
-    {
-        "name": "Safe",
-        "type": "Infrastructure",
-        "logo": "https://pbs.twimg.com/profile_images/1977658420296630272/BYnU2aa-_400x400.jpg",
-        "website": "https://safe.global/",
-        "description": "Multisig security for your onchain assets",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xf48f2b2d2a534e402487b3ee7c18c33aec0fe5e4",
-            "0x7cbb62eaa69f79e6873cd1ecb2392971036cfaa4",
-            "0xd9db270c1b5e3bd161e8c8503c55ceabee709552",
-            "0x3e5c63644e683549055b9be8653de26e0b4cd36e",
-            "0xa238cbeb142c10ef7ad8442c6d1f9e89e07e7761",
-            "0x40a2accbd92bca938b02010e17a5b8929b49130d",
-            "0xa6b71e26c5e0845f74c812102ca7114b6a896ab2",
-            "0xa65387f16b013cf2af4605ad8aa5ec25a2cba3a2",
-            "0x59ad6735bcd8152b84860cb256dd9e96b85f69da"
-        ]
-    },
-    {
-        "name": "SatLayer",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1963054824397905920/egENXUnR_400x400.png",
-        "website": "https://www.satlayer.xyz/",
-        "description": "The new financial system, built on Bitcoin: SatLayer is the economic layer for Bitcoin, making the best asset now fully programmable.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6CaEAFfC53B91094542B6cB9C51f448DB74dfd8C"
-        ]
-    },
-    {
-        "name": "Sela Network",
-        "type": "AI",
-        "logo": "https://pbs.twimg.com/profile_images/1823231837654945792/8gX3Wmfb_400x400.jpg",
-        "website": "https://www.selanetwork.io/",
-        "description": "Sela Network is a DePIN infrastructure that connects distributed nodes using daily devices, unlocking AI's potential through real-life data accessibility",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x42eA86B7E84ea022aa902C6dC470758BA68A7506"
-        ]
-    },
-    {
-        "name": "Sherpa",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1917218700479901696/1-PQqv8G_400x400.jpg",
-        "website": "https://sherpa.trade",
-        "description": "A suite of user-facing defi applications for automating strategic trading and yield capture methodologies.  Monad focused - multichain enabled.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x96043804D00DCeC238718EEDaD9ac10719778380",
-            "0x58fC8a79055519af779308a60A7f1315cAA266Af",
-            "0xF9BC71BEDEB6ba90de4cf79f09870d99B0ba2bF0",
-            "0xFA82B15CcA7668f011171a026895dde0DefCc46b",
-            "0xF37dD3ACbCB7B3BE161F8F67d09273D5Bc09Bd85",
-            "0x35708afD736873c92134adDBD2c76689993Ab9C4",
-            "0x352c308f0CB6f6B9443CBf38b89e62ca7808A61A"
-        ]
-    },
-    {
-        "name": "Skate AMM",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1873921084871106563/NEW0LSI6_400x400.jpg",
-        "website": "https://skatechain.org",
-        "description": "Unified liquidity DEX powering cross-VM actions",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x0ca6DB88ad5EeC56ca982FB96a24AD2172B4A0eF",
-            "0x430b6E7f7D43D70786267AF7a5B2C1831372ca24",
-            "0x79e31A114E6D2F16E1E2A3EC47C82FAc520881a4",
-            "0xa5646a57EB83Ad2636c08b592D7714d860BE9Fa8",
-            "0x4b13d62a8209b3b25EdCA3046DCb83167F9FeA94",
-            "0xFBD495862410c549f200Ce224Ad3D02a0bAe260D",
-            "0xC2bE4b8852E37ECf979b3E2b5d58162719303804",
-            "0x0B6414dF25eb6D23B7089055885C3d9058b33DEe"
-        ]
-    },
-    {
-        "name": "StakeStone",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1988481903138390016/cRR78wOD_400x400.jpg",
-        "website": "https://stakestone.io",
-        "description": "Autonomous Neo Banking.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x095957CEB9f317ac1328f0aB3123622401766D71",
-            "0xEc901DA9c68E90798BbBb74c11406A32A70652C3"
-        ]
-    },
-    {
-        "name": "Stork",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1899474008195637248/-nVBNuKn_400x400.jpg",
-        "website": "https://www.stork.network/",
-        "description": "Stork, the fastest-growing oracle, offers over 355 real-time feeds for dApps, helping developers build Web2-level speed and efficiency.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62"
-        ]
-    },
-    {
-        "name": "Sumer",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1469005991182143488/ixs_Wjtq_400x400.jpg",
-        "website": "https://www.sumer.money/",
-        "description": "Sumer is a highly capital-efficient blockchain liquidity infrastructure that unifies lending, synthetic assets, and cross-chain liquidity into a single pool. With its synthetic money multiplier, Sumer enables users to earn yields across multiple blockchains without missing native DeFi opportunities on their home chain.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x332F124323A1DA3Aeca4860f3B2B4a4c0df232Ae",
-            "0xBB134359b3E6794127c7232680F959CE6BF60814",
-            "0x0f0af0e3dEb8A884fCB54907BA571c84C2EB3042",
-            "0x2d9b96648C784906253c7FA94817437EF59Cf226",
-            "0x16C7d1F9EA48F7DE5E8bc3165A04E8340Da574fA",
-            "0xe19FD48C972E2dB074C4B0B29Ff2f0d3E1aefe52",
-            "0xF4DB30E806609516D14cDB53D9bc306c99505451"
-        ]
-    },
-    {
-        "name": "Supra Oracles",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1749358202985295872/FcxNf6dw_400x400.png",
-        "website": "https://supra.com/",
-        "description": "Supra Oracles delivers a decentralized, high-performance oracle infrastructure that connects real-world data with smart contracts across a wide range of blockchain platforms.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x58e158c74DF7Ad6396C0dcbadc4878faC9e93d57"
-        ]
-    },
-    {
-        "name": "Swaap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1792539314644983808/W7KOEEmP_400x400.jpg",
-        "website": "https://www.swaap.finance/",
-        "description": "Swaap is the most efficient onchain liquidity source",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xd315a9c38ec871068fec378e4ce78af528c76293",
-            "0xCc74BD5d8D2d333D14475e022325555ebA3369B8"
-        ]
-    },
-    {
-        "name": "Switchboard",
-        "type": "Oracle",
-        "logo": "https://pbs.twimg.com/profile_images/1993016007540031488/gtRyjWYe_400x400.jpg",
-        "website": "https://switchboard.xyz",
-        "description": "Switchboard is a multi-chain, permissionless oracle protocol allowing developers to fully control how data is relayed on-chain to their smart contracts.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x33A5066f65f66161bEb3f827A3e40fce7d7A2e6C"
-        ]
-    },
-    {
-        "name": "Swyrl",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1925440558769872897/j1BXlrTp_400x400.jpg",
-        "website": "https://swyrl.finance/",
-        "description": "Swyrl is a Monad-native DEX with dual AMMs and liquid staking, aligning users and protocols via ve(3,3)-driven governance.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x020e762D529628aDd359a9f4D2f63A3BCFe373Bd",
-            "0xD158CDfeC90E9429A290c3144Afeb72E8C23603a",
-            "0xa6931259B8921F2ED1E7B6c2E657e82873C195ed",
-            "0x10974f1aEE2983b052cD0EF2321Fa7d3edf2B426",
-            "0x02a898F85a6984213Ac6d2577ff3406394172abf",
-            "0x66ae3f94EB3Ab532cC4F8fC8700f6d7488E40A4f",
-            "0x6B096391742bAaEd539Ad25F44dC775065f73322",
-            "0xb79bA9375Fc66C4ddF236BeD3D53ef6213aac7B6",
-            "0xE6c40D7cDc1F1622Ddf2af41ae8c4230A587D133",
-            "0xfDD71E68FE7C3565C5fEaE6Bf3057F9841Fe1F8D",
-            "0x65552047E14028B6c20EB58f305F7663d87013A1",
-            "0xA1164853b6Ad6EfC8B28dEcA0aE5CCbf5CE88328",
-            "0xd8De315eE724CEfD5a4f215daE3d6729e5150a90",
-            "0x95d4063ad9cEDA0d83428986d23BaA9eD5163F58",
-            "0x32D14d57c60A4A213EB4cF76Cb805776D869Bffb"
-        ]
-    },
-    {
-        "name": "Symphony",
-        "type": "AI",
-        "logo": "https://pbs.twimg.com/profile_images/1893386930605211648/-APwnLNM_400x400.jpg",
-        "website": "https://www.symphony.io/",
-        "description": "Symphony is the missing infrastructure layer that connects AI to financial markets. We provide secure, autonomous execution rails so financial platforms can plug in and scale their AI products.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x0e2472E42aE6dF7674C6C4C807cD45F6d47A2A1b",
-            "0xC4a15e24D5aa36c63941B1992A28661bF215e968",
-            "0x527849787Bb79CbEde5ebEd438E685C3B56abB98",
-            "0xE1A5d791F293BA2A32613939D7012B509883EB5e",
-            "0xB64e8Cd2633D4AF5A41a8FDF5e8002FD2f072A83",
-            "0x32aef4656e2cd5b41567225C2933EC72E956e5d0",
-            "0x6E5E5f7adbA00b2e3867DbF2e6E662Eb98208f75",
-            "0x24561A639089126AdDAe7C63c66df668404f94FA",
-            "0xb1Ba36f63569E48E054Eb8BeC0b9A1C13fE2Ac8f"
-        ]
-    },
-    {
-        "name": "TKGasStation",
-        "type": "Infrastructure",
-        "logo": "https://pbs.twimg.com/profile_images/1617589580298846209/P1Shd_R9_400x400.png",
-        "website": "https://turnkey.com",
-        "description": "Gas abstraction for EVM chains that support EIP-7702 using signed intents",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x000066a00056CD44008768E2aF00696e19A30084",
-            "0x00000000008c57a1CE37836a5e9d36759D070d8c"
-        ]
-    },
-    {
-        "name": "Tadle",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1962529150989910017/aa6APvTI_400x400.png",
-        "website": "https://tadle.com/",
-        "description": "The Parallel Sandbox opening a new dimension of accessing dApps.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x89d6AeE63Bd92A9a021d3c4943a66C8e4C8D31f9",
-            "0xA8DD40CE8d5fCA018160D21d5142fB4F938F5453"
-        ]
-    },
-    {
-        "name": "Talentum",
-        "type": "Social",
-        "logo": "https://pbs.twimg.com/profile_images/1887928331066060801/_ahPl-Y4_400x400.jpg",
-        "website": "https://talentum.id/",
-        "description": "An interactive SocialFi platform that blends quests, engagement, and digital collectibles. Earn rewards for meaningful activity, discover new ecosystems, and grow your reputation on-chain.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x4816287183534B5ced5Ee93f098962d7Db144845",
-            "0x5768aF66FcFF11328FDe25398cC61BB201185697",
-            "0xe610baf2D321199be47ba943F2610Bc82bAB774B",
-            "0xf42d150e621b7bE050beb71C0f6E89A63BfaA95F",
-            "0xe3885a21005434c53d945c3A717Bcb23B49412E9",
-            "0x429b401717130d24ED5c92805141442defB6cE1D",
-            "0x05F9DfEf3E95228695BF449d96181b785144b456",
-            "0x28849Cc5A79CE2f94958FF8f853140bce865DAfA"
-        ]
-    },
-    {
-        "name": "Timeswap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1879076220106678272/ZkkhrcyV_400x400.jpg",
-        "website": "https://timeswap.io/",
-        "description": "Timeswap is the first oracleless lending/borrowing protocol that enables the creation of money markets for any ERC-20 tokens. It offers fixed interest lending and borrowing, non-liquidatable loans, isolated risk profiles, and more.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x9515507fC36174e0BAbac382B6640ef2325E61da",
-            "0xBf90d2d8E629cA48CF001F1CA6aDb47f120Fb91a",
-            "0x1c65868b41d5d69146246e3e44b66804d2698C6d",
-            "0x3D7407988B6B3589dcd949B647Fe1F0ec80d5002",
-            "0xCA9Fea121C08F7B71f4625af75c9A8bfC7AdbC3B",
-            "0x69A88955d83d7952142dDA9C688716CA51bC7EeB",
-            "0xC04766f87953C5693C18C976E4b26eF24520B570",
-            "0x49028cb356D9Aa33b996e2Bb17D708044f54d01d",
-            "0x5752513819a784dDc1393b137E9Ac244B17806db",
-            "0x5B598635aECa23690e5B6F3C33C7bD7C79516D62",
-            "0xba37DbAf63c61e056D3C44dBcc7D36898bA54441",
-            "0x48B9837385Ae1C3efC3170207279f1867FC67983",
-            "0x369071882Fa8C1CD3360123Dd9fF2AF4C435D311",
-            "0x53BD5307373d622059CeD2c10E4e8485FE50C4C9",
-            "0xe7C07C840260a9768332C8AF1Ae95941debEA0D1",
-            "0xa37A55Bdf9a3227610b61ef4446670ED4b763B86",
-            "0x0C67b8aa57E66978cC3d11AEE602376429E2A567",
-            "0x7e226A29A54050181d1BFC8A490840F62203F0F4",
-            "0xbc0800cf33Da737a069C8Cf7189C69AAd703F0Fe",
-            "0xCecd8827deF5ba6048d9B374cDA1ABfD9bf857EC",
-            "0x6ef942FAEC47Cac5538f429c734Bf1B98F963a26",
-            "0xBA43a58FC290663415556441098047645910c44D",
-            "0x235272e5e7561505011729b30B2aa57bd9EF6eAC",
-            "0x99359eab05a8E2464bFcaa00eac28E0201845A53",
-            "0x73A76aff6DC8acA146bC7878c5Bf686156D3B519",
-            "0x1c0132b292E34Bb6A05eedB979046e117C8d55dc",
-            "0xCCE1f61DC39e157A63675145a0ffb50065c2F56D",
-            "0xdB81aA023d1b2465a93087Ef829Ae438643939cf",
-            "0xFfc95ED4DB5a43FD3bB9fDAcd2B9409D01167b2a",
-            "0xDca2644D1F0900740158a64cBdc339b0514a4947"
-        ]
-    },
-    {
-        "name": "TownSquare",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1563311542334267398/gaQXK0FD_400x400.jpg",
-        "website": "https://www.townsq.xyz/",
-        "description": "TownSquare is a modular money market that powers crosschain lending & leveraged yield.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xed84c02a0787d56d0b53efe64dd60a1ae20e4e31",
-            "0xb4a545a183bd072548ddfe9ddadc2c6f962ac14f",
-            "0x8f8a0ed366439576b7db220678ed1259743239e3",
-            "0xc2df24203ab3a4f3857d649757a99e18de059a16",
-            "0x428cfa65310c70bc9e65bddb26c65fe4ca490376",
-            "0xc4c20efbefa4bde14091a3040d112cf981d8b2db",
-            "0x2970fde6064178d51d961689cb5b64226ab11fc2",
-            "0x2dfdb4bf6c910b5bbbb0d07ec5f088e294628189",
-            "0x63cb1cf5accbcc57e0cca047be9673ea5022b8db",
-            "0x0392354326960f891926835eedab127766b21668",
-            "0xa457235b68606a7921b7c525d92e9592e793b4c0",
-            "0xa2b1ac2bb0a6ad5e74d74f8809a2f935813d273a",
-            "0xdb4e67f878289a820046f46f6304fd6ee1449281",
-            "0xf358f9e4ba7d210fde8c9a30522bb0063e15c4bb",
-            "0x106d0e2bff74b39d09636bdcd5d4189f24d91433"
-        ]
-    },
-    {
-        "name": "Uniswap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1831348758753206272/y2Z0hMrl_400x400.jpg",
-        "website": "https://app.uniswap.org/",
-        "description": "The largest onchain marketplace. Buy and sell crypto on Ethereum and 11+ other chains.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x182a927119d56008d921126764bf884221b10f59",
-            "0x4b2ab38dbf28d31d467aa8993f6c2585981d6804",
-            "0x204faca1764b154221e35c0d20abb3c525710498",
-            "0xd1b797d92d87b688193a2b976efc8d577d204343",
-            "0x661e93cca42afacb172121ef892830ca3b70f08d",
-            "0xf025e0fe9e331a0ef05c2ad3c4e9c64b625cda6f",
-            "0x2e9d45bb7b30549f5216813ada9a6b7982c5b3ed",
-            "0x315e413a11ab0df498ef83873012430ca36638ae",
-            "0x7197e214c0b767cfb76fb734ab638e2c192f4e53",
-            "0x7078c4537c04c2b2e52ddba06074dbdacf23ca15",
-            "0xd6145b2d3f379919e8cdeda7b97e37c4b2ca9c40",
-            "0x188d586ddcf52439676ca21a244753fa19f9ea8e",
-            "0x5770d2914355a6d0a39a70aeea9bcce55df4201b",
-            "0x5b7ec4a94ff9bedb700fb82ab09d5846972f4016",
-            "0xa222dd357a9076d1091ed6aa2e16c9742dd26891",
-            "0x77395f3b2e73ae90843717371294fa97cc419d64",
-            "0x2d01411773c8c24805306e89a41f7855c3c4fe65",
-            "0x0d97dc33264bfc1c226207428a79b26757fb9dc3",
-            "0x5c834b6cac4173bfe288c5722a38e04b9e366e30"
-        ]
-    },
-    {
-        "name": "Upfloor",
-        "type": "NFT",
-        "logo": "https://pbs.twimg.com/profile_images/1979463970391035904/doN2Je6V_400x400.jpg",
-        "website": "https://upfloor.co/",
-        "description": "Transforms NFT collections into perpetual growth engines",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xB16EAa34cA11291a70Acfc16440F3aABAf89E332"
-        ]
-    },
-    {
-        "name": "Wormhole",
-        "type": "Bridge",
-        "logo": "https://pbs.twimg.com/profile_images/1967993658080133120/VSOooFaD_400x400.jpg",
-        "website": "https://wormhole.com/",
-        "description": "Wormhole is a generic message-passing protocol designed to enable secure and efficient communication between different blockchains. ",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x194B123c5E96B9b2E49763619985790Dc241CAC0",
-            "0x0B2719cdA2F10595369e6673ceA3Ee2EDFa13BA7",
-            "0x36878C6FCa7e0E8a88F90dc410CfBBcA5B695C95",
-            "0x92957b3D0CaB3eA7110fEd1ccc4eF564981a59Fc",
-            "0x1a0f31492Ca69DF6A82906Ce88613AeCD9245C44",
-            "0x7e0AF7c98CBf443B345d718C3787f3f86AdbC51D",
-            "0xf3C52C28Ddd282a96841933bb0Cb85Ba0fCB2FA0",
-            "0x0DAB1c1733F1a9b84c90b08Da78Db014B3b13AB5",
-            "0xC04dE634982cAdF2A677310b73630B7Ac56A3f65",
-            "0xA4d775410FB35d8cE49Ad98d3f483A55e532de73",
-            "0xD64341A38a5eAfb9EB9BACf8A5C52Fe858c4ABE9",
-            "0x93FE94Ad887a1B04DBFf1f736bfcD1698D4cfF66",
-            "0xFEA937F7124E19124671f1685671d3f04a9Af4E4",
-            "0x0E4Eaf9c5c74bec4Cb651394db4847f77700e175",
-            "0x13b62003C8b126Ec0748376e7ab22F79Fb8bbDF2",
-            "0xf7E051f93948415952a2239582823028DacA948e",
-            "0x412f30e9f8B4a1e99eaE90209A6b00f5C3cc8739"
-        ]
-    },
-    {
-        "name": "Yap Market",
-        "type": "Social",
-        "logo": "https://pbs.twimg.com/profile_images/1915456612401025024/a4kyUymg_400x400.jpg",
-        "website": "https://yap.market/",
-        "description": "Yap Market is an on-demand attention marketplace built on Kaito that helps crypto projects launch high-impact distribution campaigns. We reward creators for real results from engagement to onchain conversions, not vanity metrics.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x29957e3b3DaBeDBE830b0De53C2C9293d0DB1bda"
-        ]
-    },
-    {
-        "name": "aPriori",
-        "type": "LST",
-        "logo": "https://pbs.twimg.com/profile_images/1821177411796410369/GtzmUXok_400x400.jpg",
-        "website": "https://www.apr.io/",
-        "description": "The intelligent order flow coordination layer for high performance blockchains",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x0c65A0BC65a5D819235B71F554D210D3F80E0852",
-            "0x77F6e4103e32D6146e29cF9eD1645e170F90BC2b"
-        ]
-    },
-    {
-        "name": "earnAUSD",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1853600042952663040/AwOMmTi1_400x400.jpg",
-        "website": "https://upshift.finance",
-        "description": "The primary liquid yield token on Monad, systematically allocating AUSD across top DeFi opportunities",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA",
-            "0x04ae5a71eA943f9Fc4ECB3BD4118e381cD04067D",
-            "0x103222f020e98Bba0AD9809A011FDF8e6F067496",
-            "0x942147E26B4F320b1f1D34895497aB59a56DceeC",
-            "0x95f3458Cb7FE0fd8D22DA406F688aa6Ac74AEa84",
-            "0xceA701f0Ff0a2e8A51a5C5c1D2B6b69BFA849989",
-            "0x0000000000000000000000000000000000000000"
-        ]
-    },
-    {
-        "name": "ESP.Fun",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1963349327998230528/RVQ-t5AG_400x400.jpg",
-        "website": "https://esp.fun/",
-        "description": "ESP.Fun is a fantasy esports gaming platform featuring player tokens, pack opening systems, and decentralized trading via automated market maker pools.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xC99a1D62a453481B24C5364403E61c4254218d28",
-            "0x3C1bCd19455f3fA33234fAf9c73F9E6EA055A899",
-            "0x26448Da45e80709B3E4ADfFa4a98c62925ea836f",
-            "0x7F51991A3C9c779a841caefeEE4c0167BF6f871A",
-            "0x5159373fe2D88BbC217a9860AE739eb3294d9e12",
-            "0x81dE118EaECa76df364458d76Ad1f2F02fA7C238",
-            "0xE4DcbD655aCBf413097CaF4576a4d9dB05aCc015"
-        ]
-    },
-    {
-        "name": "iZiSwap",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1509704804032937991/5qVVZwJj_400x400.jpg",
-        "website": "https://izumi.finance/trade/swap",
-        "description": "A multi-chain DeFi protocol providing One-Stop Liquidity as a Service (LaaS).",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x8c7d3063579BdB0b90997e18A770eaE32E1eBb08",
-            "0x4d4673745AAC664eFB9758fdd571F40d78a87bfe",
-            "0x32D02Fc7722E81F6Ac60B87ea8B4b63a52Ad2b55",
-            "0xF4efDB5A1E852f78e807fAE7100B1d38351e38c7",
-            "0xe96526e92ee57bBD468DA1721987aa988b008768",
-            "0xbD6abA1Ef82A4cD6e15CB05e95f433ef48dfb5df",
-            "0x19b683A2F45012318d9B2aE1280d68d3eC54D663",
-            "0x02F55D53DcE23B4AA962CC68b0f685f26143Bdb2",
-            "0x2db0AFD0045F3518c77eC6591a542e326Befd3D7",
-            "0x3EF68D3f7664b2805D4E88381b64868a56f88bC4",
-            "0x33531bDBFE34fa6Fd5963D0423f7699775AacaaF",
-            "0x34bc1b87f60e0a30c0e24FD7Abada70436c71406",
-            "0x3F559139C2Fc7B97Ad6FE9B4d1f75149F551DB18",
-            "0x04830cfCED9772b8ACbAF76Cfc7A630Ad82c9148",
-            "0x2C6Df0fDbCE9D2Ded2B52A117126F2Dc991f770f",
-            "0x14323AfbC2b82fE58F0D9c203830EE969B4d1bE2"
-        ]
-    },
-    {
-        "name": "Kansei",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1965511338270052352/Ro1SsJIM_400x400.png",
-        "website": "https://kansei.finance/",
-        "description": "All-in-one trading / yield leverage / liquid staking SuperApp with near instant UX.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x6B672532B4347B56236ceeD8a2410Aec4395FdB2",
-            "0x33d4220003A120b07F0A764a6C9A70e6D328C461",
-            "0xDa3A330073c10eB00AFc322F77BC24ed289D083F",
-            "0xe665DE7AAD6B20cAfa4BEe85b6B27a4000b106e4",
-            "0xcB79E3EdB6Bf3d7e66e3f685cd9F2373F462f4f3",
-            "0x8F8420CFeD0B9F84f3b4c593494D288F8a4A84C4",
-            "0x41D5eF83d666Bed43D78bc467C844512f27F5d03",
-            "0xaD2074EBBd819f47aC936CDADC5F3FC8A6609f00",
-            "0xeBA09ADcb1D0052745CEadf0e9c3A87E2Ab11B2f",
-            "0x0493B0f962346AadCaB77ABc6d24a9c69A74962b",
-            "0x58BA4Db931da0509b7F0b7477925dE3e9a20CE1A",
-            "0x2632662f3750EE27b025D44ADFF0B86839D0BeC1",
-            "0x4834a84C17c2a449054e0ad1e0FC63cd5512bFd2",
-            "0xfD792edCe7926484c560466A6A4C7952602670EA"
-        ]
-    },
-    {
-        "name": "Lagoon",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1990443288290013184/3nySPoed_400x400.png",
-        "website": "https://www.lagoon.finance/",
-        "description": "LAGOON provides open, general-purpose, secure vault infrastructure to build and scale on-chain yield products.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xBf994c358f939011595AB4216AC005147863f9D6",
-            "0xcCdC4d06cA12A29C47D5d105fED59a6D07E9cf70"
-        ]
-    },
-    {
-        "name": "Mevx",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1991722130132828160/DySjqo2x_400x400.jpg",
-        "website": "https://mevx.io/",
-        "description": "MevX is your go-to platform for all things crypto trading and data analysis",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x92ef088BC025EBaf7C9521dFa82130d33934EB30",
-            "0xd1f47ef81354663F3786b62B5B95C1015dA48CA4",
-            "0xC67134cc40765fc28e2d54f58Cd93d382D9137d8",
-            "0xa26326Af694D03A12250df01733B173c05153A76",
-            "0xf867f2bfd6C1926770E6451A72B2899231678A56"
-        ]
-    },
-    {
-        "name": "Morpho",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1990342665846599680/V6YT8dQv_400x400.jpg",
-        "website": "https://morpho.org/",
-        "description": "The universal lending network",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xA16B49505e39C373A8f9e1b1540514BA64B3942a",
-            "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
-            "0x09475a3D6eA8c314c592b1a3799bDE044E2F400F",
-            "0xe27f43624FDb5325b853c4711BCF0fEBA754e558",
-            "0xfd70575B732F9482F4197FE1075492e114E97302",
-            "0x6C3A89e814A9D150cD763f443dceE5EBC5bF60b6",
-            "0x907a393Ad715Ac63389EEc3236FaC74E7D68a4ee",
-            "0x33f20973275B2F574488b18929cd7DCBf1AbF275",
-            "0xC8659Bcd5279DB664Be973aEFd752a5326653739",
-            "0x0a3c9f732C7E987ddbBaac13309A8B552aa50872",
-            "0x6F12916F559dC7f86a86cD3e33BFebE6348f979A",
-            "0xE8233125be3ecD274b8007618315Dd2f3361eced",
-            "0x6D0090dB99919d1594B9b824D295E923266C9052",
-            "0x6A99Cc46825A724B41f8E5656935929FA0a2cB2C",
-            "0xA3E73eC1792bb127B0915dE9842eB999C12C0c34",
-            "0xFf08983fAA3D689c8C8527Bd69f90Ea46d170db9",
-            "0x03877DB7cAa28bC522DbB8c060eeAEB086020B83",
-            "0xB5b3e541abD19799E0c65905a5a42BD37d6c94c0",
-            "0x82b684483e844422FD339df0b67b3B111F02c66E",
-            "0x725AB8CAd931BCb80Fdbf10955a806765cCe00e5",
-            "0x273dBC3f178D03fA9D385e61Ee1E11dCf563EE14",
-            "0xF4c840eA6fdD0493F77Ef0141C5a5a09Cd384918",
-            "0x22C3024C7E1e149d7E49766cd047a2da081E4EAF",
-            "0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c",
-            "0x8Da54fbF89B3D6fC6DCC92F31CF75a211ACF3d46",
-            "0x9f3c0999425656fD189C69a8aD68cB64986D644A",
-            "0xc1108C5d98DC09BE44e656A9E34B04D37b90a50d",
-            "0xD155AF55cF966886cc197F05399bE4a033af7090",
-            "0x549bf7A3346eBEbe88BD3FcaD8Ab1f23De8Eb4e4",
-            "0xa1a2ca8feB4d08a7123BFBB0A269501F885264DE",
-            "0x71dd91258eca11fC045098774Ec2F331126A0b53",
-            "0x6a42f8b46224baA4DbBBc2F860F4675eeA7bd52B",
-            "0xF5e6DD4b06874f55444936cF0026b785383A9849",
-            "0x1d721eddac84e1B9995Fc25ce3e57463688064a9",
-            "0x3f12264881a118C2A74Ad10F9039694579bdCf54"
-        ]
-    },
-    {
-        "name": "TeleMafia",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1967887075316994050/STzEqU1y_400x400.jpg",
-        "website": "https://mafia.family/",
-        "description": "TeleMafia is a Telegram-native social mafia RPG where Families compete, earn Respect, and grow shared on-chain Treasuries powered by Monad.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xA5A6F68A3fcE8D345Be024d0E0Bf4240Bc620Be4",
-            "0x777AcAb541A663ABbad28de92Af6caeFD67c72CD",
-            "0xaE2DfCa11311e1652B9d3dC39527465435eA94ef",
-            "0x5d1814D6981247bc796CA3F48d5Cc382dd552552",
-            "0xCbA51d62D0B240Bb8f60eee98351464beaa5Cc77"
-        ]
-    },
-    {
-        "name": "Thevapelabs",
-        "type": "DePIN",
-        "logo": "https://pbs.twimg.com/profile_images/1844811987034972160/OkkeVD3C_400x400.jpg",
-        "website": "http://thevapelabs.io",
-        "description": "TheVapeLabs is the world\u2019s first AI-powered smart vape brand, built on Monad. We help people cut down and quit nicotine with real-time tracking, personalized AI tips and incentives. Users can even flex their NFTs right on the device, bringing on-chain culture into real life.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xfA2F863Eb512434E99E2365Fa5f7AC7674DDe000",
-            "0x51FFf43eb9Cc9cE9de491E86dcfBFbf0864cfEED",
-            "0x925726a0AAbB82464d21F6795A457fA9Fe0a57c1"
-        ]
-    },
-    {
-        "name": "SLAB CASH",
-        "type": "Collectibles",
-        "logo": "https://pbs.twimg.com/profile_images/1944817732647542784/KOF2eYVo_400x400.png",
-        "website": "https://slab.cash",
-        "description": "Level up your collection with physical backed, onchain authenticated trading cards.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xC2DC75bdd0bAa476fcE8A9C628fe45a72e19C466",
-            "0x8a981C2cfdd7Fbc65395dD2c02ead94e9a2f65a7",
-            "0xb85D2443aEfbCaf9f0b32EAde7D47BeBc5D00972"
-        ]
-    },
-    {
-        "name": "Memenads",
-        "type": "DeFi",
-        "logo": "https://pbs.twimg.com/profile_images/1993957015132209153/v64sdIcG_400x400.jpg",
-        "website": "https://memenads.fun",
-        "description": "Memenads.fun is a one-click meme token launchpad that lets anyone create, deploy, and trade meme coins instantly. No coding required\u2014launch your token in seconds and grow your community with built-in tools.",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x0d3c2cfab83920236f266e70076b0d502cd060d0",
-            "0x5f810dd164668ef52f60bf7e9830ac2dc3f7b1e8"
-        ]
-    },
-    {
-        "name": "Wordle Fun",
-        "type": "Gaming",
-        "logo": "https://pbs.twimg.com/profile_images/1994437577475035136/VwjOn7jE_400x400.jpg",
-        "website": "https://www.wrdl.fun/",
-        "description": "Wrdl.fun is an on-chain word game built on Monad, inspired by the iconic Wordle format and enhanced with real on-chain incentives",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x6FBB86d5940B11E23056a66a948d97289Bd320eB"
-        ]
-    },
-    {
-        "name": "Curvance",
-        "type": "Lending",
-        "logo": "https://imagedelivery.net/cBNDGgkrsEA-b_ixIp9SkQ/Curvance.png/public",
-        "website": "https://www.curvance.com/",
-        "description": "Click Less, Earn More.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0x1e240E30E51491546deC3aF16B0b4EAC8Dd110D4",
-            "0x926C101Cf0a3dE8725Eb24a93E980f9FE34d6230",
-            "0x8EE9FC28B8Da872c38A496e9dDB9700bb7261774",
-            "0xE01d426B589c7834a5F6B20D7e992A705d3c22ED",
-            "0xAd4AA2a713fB86FBb6b60dE2aF9E32a11DB6Abf2",
-            "0x0fcEd51b526BfA5619F83d97b54a57e3327eB183",
-            "0x6E182EB501800C555bd5E662E6D350D627F504D8",
-            "0x852FF1EC21D63b405eC431e04AE3AC760e29263D",
-            "0xfD493ce1A0ae986e09d17004B7E748817a47d73c",
-            "0x2B4e0232F46E6DB4af35474c140B968EeFCB09Ec",
-            "0xF32B334042DC1EB9732454cc9bc1a06205d184f2",
-            "0xD9E2025b907E95EcC963A5018f56B87575B4aB26",
-            "0x92EE4b4d33Dc61bd93a88601F29131B08aCedBF1",
-            "0x5af9b7cAc0530d3C9e11C23B7A69Cce335B8C395"
-        ]
-    },
-    {
-        "name": "zkSwap Finance",
-        "type": "DeFi",
-        "logo": "https://assets.coingecko.com/coins/images/31633/standard/200x200_Black.png",
-        "website": "https://www.zkswap.finance",
-        "description": "A multichain decentralized exchange that offers a Swap2Earn model, designed to provide incentives for both liquidity providers and traders",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xF82343c8b777BAdB0921ee4c4F7581c968687B6b",
-            "0xC60cBC14D170A95938bb630AE78a8306dd7cF120",
-            "0x68225b5ba7cE309fD0d3f0C9A74b947c7d7e03dA",
-            "0x0ff16867BcaC3C5fdc2dc73558e3F8e2ed89EEA2",
-            "0xf5Cf2b71B8B368c84C4C4903AF453E790d392285",
-            "0xCe98a0E578b639AA90EE96eD5ba8E5a4022de529",
-            "0x98356a6276e0413FF21d41a17EB851dB9207A285",
-            "0xC5AB2BE64e27e43778C9AA692cf058ba043BC32a",
-            "0xb41bFa454808eE4d35638a225cc91389A5295e7F",
-            "0xcf7ff4717D5E1468C82aA69Dba8dAcb18eD5B585",
-            "0x734711633eF2c9a2386BE0eA1C010b06FB3b94Aa",
-            "0x45728A3D03fF67Cc0c8546f4290aFFB7C94F877a",
-            "0x486D7C009B78310528AcA11574eC816d2FdEf71B",
-            "0x2f2f2f74ab5db61AE8BD3c13ccD4Dc8c9E8A2f2f",
-            "0x123468b48EADbC13c65cd9c66A9913cdE4e94321",
-            "0x0aa3e6692e4E8845e21867b520A2Bb0377199350",
-            "0xF5AC2cE5002272EA0042a4Ba3dcBb45fd2b8A021"
-        ]
-    },
-    {
-        "name": "MonBridgeDex",
-        "type": "DeFi",
-        "logo": "https://avatars.githubusercontent.com/u/210091763?s=400&u=d0acd4299e071def2fe61e0acd6216deda67d320&v=4",
-        "website": "https://monbridgedex.xyz",
-        "description": "Mon Bridge Dex is an advanced aggregator that bridges multiple DEXes to secure the best swap output for your trades on Monad",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x7dd7fc9380e3107028a158f49bd25a8a8d48b225",
-            "0xd2748ceA2ADa9Bfc4eDA8AD7fe170f8a6A0EABe8"
-        ]
-    },
-    {
-        "name": "Color - RgbClash",
-        "type": "Game",
-        "logo": "https://www.rgbclash.xyz/center_filled.png",
-        "website": "https://www.rgbclash.xyz/",
-        "description": "Unleash your creativity and draw your yield bearing NFTs. Play to earn with multiplayer drawing-guessing game.",
-        "monad_exclusive": false,
-        "contracts": [
-            "0xC8bB93e4f11665D76C704d973e744d78b3d32A2c",
-            "0x2aF76C4e57886Aac03329a6dfF02761F250848A3",
-            "0xb25Ef8643414e6bb29E9eF24E8fD7dC9115b26e1",
-            "0x1f5E4a0fFaB85E5BBa68f73f878117eD314e4452",
-            "0x9Cc79CE554a6CebCE2EC90DAb0F77E6b08e89563"
-        ]
-    },
-    {
-        "name": "dFusion AI",
-        "type": "AI, Infrastructure",
-        "logo": "https://cdn.prod.website-files.com/660ab3687f4b08443800247f/672240e6f55de869b96f325e_Light%20Logo.svg",
-        "website": "https://testnet.dfusion.ai",
-        "description": "dFusion AI turns curated data into specialized & accurate AI subnets, aligning usage, incentives, and ownership.",
-        "monad_exclusive": true,
-        "contracts": [
-            "0x9ED42CeBA267C3f7728Cc1F559cd7b545D7CD7d4"
-        ]
-    },
-    {
-        "name": "Monday Trade",
-        "type": "DeFi",
-        "logo": "https://mondaytrade.notion.site/Monday-Trade-Brand-Kit-1f948d36614f807bb374c003d7c35e70",
-        "website": "https://app.monday.trade",
-        "description": "Monday Trade is Monad\u2019s native spot and perps DEX that offers the best of CEX and DEX trading experience",
-        "monad_exclusive": true,
-        "contracts": [
-            "0xAD8974D98f7fc386e396FFE826B886cf20AfE232",
-            "0x68b507BF58ED32173f41FF20aa2494A569daeC44",
-            "0xB97eCD41Aef0F842E773C8F9905919cDE49880C9",
-            "0xFE951b693A2FE54BE5148614B109E316B567632F",
-            "0xC1e98D0A2a58fB8aBd10ccc30a58efff4080Aa21",
-            "0xdc67221ea8D223E0A1D0948eDeCB634cAF190eC9",
-            "0x15bC3C13cbf5903E78b97208ba1021E5dc1B4470",
-            "0x2E32345Bf0592bFf19313831B99900C530D37d90",
-            "0xdfBA572929De47838BdE12336dfE8842B06d9628",
-            "0x5FE49fb8770A8009335B1d76496c3e07Ca04FC9F"
-        ]
-    }
+  {
+    "name": "Something",
+    "type": "DeFi",
+    "logo": "https://apricot-capable-rat-626.mypinata.cloud/ipfs/bafkreia6kcth4yagcbquyuc5vfxzuxwmcn22vorhhdjssvhjuojlzj2pga",
+    "website": "https://monad.something.tools",
+    "description": "Something delivers a full launchpad with flexible migration fees, a highly customizable AMM, and revenue sharing for creators.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x00F4353C69039b25c9338097FfF51099981E00ce"
+    ]
+  },
+  {
+    "name": "SomeSwap",
+    "type": "DeFi",
+    "logo": "https://apricot-capable-rat-626.mypinata.cloud/ipfs/bafkreicmt3l656cb6nhlotxlnvb6togtzgvc5sds32a7tnydwiwmokmepu",
+    "website": "https://someswap.org",
+    "description": "SomeSwap is a next-generation AMM and DEX built on Monad, featuring Chameleon Pools, dynamic fee tiers, anti-sniping protection, and Chimera smart routing. It powers trading, liquidity, and token launches across the Something ecosystem.",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x00008A3c1077325Bb19cd93e5a0f1E95144700fa",
+      "0x000799B28aE9C3E9ca70B7Ff67b191519ab80fee",
+      "0x001176F5eF99F53Eae957Bb2Fb2aE93E9b6F110c"
+    ]
+  },
+  {
+    "name": "0x",
+    "type": "DeFi",
+    "logo": "https://cdn.prod.website-files.com/66967cfef0a246cbbb9aee94/66967cfef0a246cbbb9aeeee_logo.svg",
+    "website": "https://0x.org/",
+    "description": "High performance APIs that aggregate DEX and private liquidity sources to provide optimal trade executions for digital asset trades.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x00000000000004533Fe15556B1E086BB1A72cEae"
+    ]
+  },
+  {
+    "name": "Accountable",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1910248229968490496/TZd8HlZa_400x400.jpg",
+    "website": "https://accountable.capital",
+    "description": "Crypto-based yields done right. Total privacy, full transparency, maximizing your yield opportunities, worry-free.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x4DE9B4d7b70d1680cD8E3A2C60717cBbe6014991",
+      "0xeE004AEF79cb14BF31BFbFB14346E01fB7e5a2e8",
+      "0x1106a70223e98E2b1807bf3e12698aFe2C5693e6",
+      "0xf786154e56e5c88Ce984800dEa71B48EA4FFAbfE",
+      "0xD0A53e724EA9CB041e30f0243E3c84bdea238Dfa",
+      "0x59B0b84371BB3261FAD538C512eFFFc414CC1725",
+      "0x8a5Caf00C3EB20aEC11Fc35C153a8601Cd127fEd",
+      "0x606556A6B544ecDcbf15aF73A63B67516dc16Ad7"
+    ]
+  },
+  {
+    "name": "Across",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1983984117092859904/0LvQEcB__400x400.jpg",
+    "website": "https://across.to",
+    "description": "Cross-chain liquidity protocol that allows users to swap tokens between different chains.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x09aea4b2242abc8bb4bb78d537a67a245a7bec64",
+      "0xeC41F75c686e376Ab2a4F18bde263ab5822c4511",
+      "0xd2ecb3afe598b746F8123CaE365a598DA831A449"
+    ]
+  },
+  {
+    "name": "AethonSwap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1963536268777979904/vX-IJ7U7_400x400.jpg",
+    "website": "https://app.aethonswap.com/",
+    "description": "AethonSwap is a next-generation decentralized exchange (DEX) designed to be the central liquidity hub of Monad.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6f85F158c2289579BE8e79a31B78F7DCd4686857",
+      "0x05aA1d36F78D1242C40b3680d38EB1feE7060c20",
+      "0xC67F01e87294a846ACEcB22d4f8D7AAbea9EA794",
+      "0xE35569726922F66a71e1279824Ba6082767E8569",
+      "0xd1814cC0FAee1EC941112F8739C47ddd0a908860",
+      "0xf31443F5d3fe6B2d026B9079F2fcEf2647A9fEcc",
+      "0x8510E4C073fb7fe75B8e767A1856F85586e24679",
+      "0x50AA60Edb77F0446b8E760B5Dc3015AD53D04d80",
+      "0xBf511a2d4f7D895F4cb8DeC448CE25a7bE211EAF",
+      "0xDD68207A952718b91d5dF31819d0676C269f1fB5",
+      "0x90dD87C994959A36d725bB98F9008B0b3C3504A0",
+      "0x41534b64b8a10b4e5C03bbB792F75f6DfCF462bF",
+      "0x545069eBd6cFA0B3028CEC5A23C37839B9EeEBaa",
+      "0x79b952a25c03b109cE6a6118F1A68a0E0113E8f3",
+      "0x26c48519bBCf6df3E39d4C724ff82B6F060D3Bbe",
+      "0x77996bd2e8272cB694D320be78CE972307D85bF9",
+      "0x217fd038FF2ac580de8E635a5d726f6f0E5214e3",
+      "0xcea03e70f95e1998D90549Aba02E5f89D1db2C90",
+      "0xFF9382865eAc4C9E79f15586Ae7ff68209419f2e",
+      "0x245f061e602E690266012E8bFBf9b5131ee66d86",
+      "0x81554Cc2aC39D03Ef5F2e879c9B3748fff61385a"
+    ]
+  },
+  {
+    "name": "ApeBond",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1912568082201018368/rp47FESU_400x400.jpg",
+    "website": "https://ape.bond",
+    "description": "The #1 Bonding Protocol in DeFi, with $20M+ bonded and 80k+ bonds sold, transforming how projects raise funds and secure liquidity.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xd731d8103132275b21A27eA8C8428Ac6B97C5D35",
+      "0xc765C358622cB346f236F8Bfffe53036e421bb4e",
+      "0x1b7858f745211dBa1387fE30124eBCa2D706D7Dd",
+      "0x1f226C1008f5De89614Bb15d09745128cf2a4D62"
+    ]
+  },
+  {
+    "name": "Atlantis",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1902110216402927616/2KI7eXdp_400x400.jpg",
+    "website": "https://atlantisdex.xyz",
+    "description": "Modular V4 DEX offering cross-chain swaps, DeFAI, a launchpad, farming, staking, fiat on-ramp, & more.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xd7cB0E0692f2D55A17bA81c1fE5501D66774fC4A",
+      "0x10253594A832f967994b44f33411940533302ACb",
+      "0x4439199c3743161ca22bB8F8B6deC5bF6fF65b04",
+      "0x955B95b8532fe75DDCf2161f61127Be74A768158",
+      "0xFe3BEcd788320465ab649015F34F7771220A88b2",
+      "0x4A3BC48C156384f9564Fd65A53a2f3D534D8f2b7",
+      "0x13fcE0acbe6Fb11641ab753212550574CaD31415",
+      "0x03f8B4b140249Dc7B2503C928E7258CCe1d91F1A",
+      "0xa77aD9f635a3FB3bCCC5E6d1A87cB269746Aba17",
+      "0x3012E9049d05B4B5369D690114D5A5861EbB85cb",
+      "0xD637cbc214Bc3dD354aBb309f4fE717ffdD0B28C",
+      "0x6AD6A4f233F1E33613e996CCc17409B93fF8bf5f",
+      "0x69D57B9D705eaD73a5d2f2476C30c55bD755cc2F",
+      "0xB4F9b6b019E75CBe51af4425b2Fc12797e2Ee2a1",
+      "0x50FCbF85d23aF7C91f94842FeCd83d16665d27bA",
+      "0x658E287E9C820484f5808f687dC4863B552de37D",
+      "0x38A5C36FA8c8c9E4649b51FCD61810B14e7ce047",
+      "0x83D4a9Ea77a4dbA073cD90b30410Ac9F95F93E7C",
+      "0x503D191CaFaB1d097b5F798d850E5897195C1d74"
+    ]
+  },
+  {
+    "name": "Axelar",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1874834853943824384/l71EkA26_400x400.jpg",
+    "website": "https://axelar.network",
+    "description": "Powering the Chain-Agnostic Future",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xe432150cce91c13a887f7D836923d5597adD8E31",
+      "0x2d5d7d31F671F86C782533cc367F14109a082712",
+      "0x50beAbe4883981624aEa01F737B040d1e3Fe83FB",
+      "0x7DdB2d76b80B0AA19bDEa48EB1301182F4CeefbC",
+      "0x98B2920D53612483F91F12Ed7754E51b4A77919e",
+      "0x6513Aedb4D1593BA12e50644401D976aebDc90d8",
+      "0xB5FB4BE02232B1bBA4dC8f81dc24C26980dE9e3C",
+      "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66"
+    ]
+  },
+  {
+    "name": "Banza",
+    "type": "AI",
+    "logo": "https://pbs.twimg.com/profile_images/1978484417505955840/SJ2MfyYx_400x400.jpg",
+    "website": "https://banza.xyz/",
+    "description": "Banza helps you build a personal AI twin that learns freely from every app you use through verifiable, privacy-preserving data capture using OPzkTLS, then earns rewards for you while delivering tailored cross-platform recommendations and proactive actions that save you time, all of it with cryptographic proof.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x68b571F834C9853d2a7E8e364d28dB52De47d46d",
+      "0x11fBE9E637C4A3DECA3453f2925AAAa18e16963E"
+    ]
+  },
+  {
+    "name": "Bean Exchange",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1981305723637166080/ubiQ-e6g_400x400.jpg",
+    "website": "https://bean.exchange",
+    "description": "The ultimate capital-efficiency Perps & DLMM Spot DEX on Monad",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8Bb9727Ca742C146563DccBAFb9308A234e1d242",
+      "0x721aC9E688E6b86F48b08DB2ba2D4B7bBBd12665",
+      "0xA398af902950081F2FBE3E16e5E474C2C72ae27a"
+    ]
+  },
+  {
+    "name": "Blocksense",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1907393414901170176/CBZG2akF_400x400.png",
+    "website": "https://blocksense.network",
+    "description": "The universal verification layer for the autonomous economy",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xADF5aaa34D0A2FbAeE73353ab1622E47d0600249",
+      "0x9CA25F9149e5204CDD1C5b7717C08Dff35A4eFc3",
+      "0x5985F6247985e0cB7750893093214A77F0F9D3cE",
+      "0x43662b6eD1EDEA444Ed2bA4e1e008403C5F32bAc"
+    ]
+  },
+  {
+    "name": "bonad.fun",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1991955935841906688/7NmCLcoP_400x400.jpg",
+    "website": "https://bonad.fun",
+    "description": "Create, trade, and build your vision",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x660eAaEdEBc968f8f3694354FA8EC0b4c5Ba8D12",
+      "0xC99b485499f78995C6F1640dbB1413c57f8BA684",
+      "0xFAafdE6a5b658684cC5eb0C5c2c755B00A246F45",
+      "0xb4deE32EB70A5E55f3D2d861F49Fb3D79f7a14d9",
+      "0x5F3bA43D44375286296Cb85F1EA2EBfa25dde731",
+      "0x136191B46478cAB023cbC01a36160C4Aad81677a",
+      "0xCe3099B2F07029b086E5e92a1573C5f5A3071783"
+    ]
+  },
+  {
+    "name": "Bro Fun",
+    "type": "Consumer",
+    "logo": "https://pbs.twimg.com/profile_images/1983519855279042560/ntgzrOaU_400x400.jpg",
+    "website": "https://bro.fun",
+    "description": "Where fortune favors the bros. Sink cups, become a legend.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xDF7A89Fc62e5120C4617f143C7AcDDAB0D1Ca7A2"
+    ]
+  },
+  {
+    "name": "Bungee.Exchange",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1938126602774450177/qEmo_mDl_400x400.png",
+    "website": "https://www.bungee.exchange",
+    "description": "Bungee provides seamless swaps between any blockchain. With over $24B in volume and trusted by major wallets and dApps, Bungee makes moving assets between networks efficient, secure, and accessible to everyone, powered by the SOCKET.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xd0389e84178f809903cbFE7D1EfAE3EFa9c1769c",
+      "0x3859AD748D03C358aAbB66d084bC5849B624E611",
+      "0xF20B3CB7508c519296556C1Caa9dB6F210e0232a",
+      "0x27D966329a325f214b4854a4F0E62550BFebdca3",
+      "0x01D8a85aDb82408E14bC242ed43fBaD0Ca2F94CB",
+      "0x1A2F1085A94De6fBcc334AAE1DDf527C567b75E7",
+      "0x3bb92b8452bDE5Ac20C18E10e606fdc9AC19b414",
+      "0x82260Eac86558C0835D08eeFF360014aEa7454b6",
+      "0xa873aab6a98cb764ad6d52820d129d0e3667d9f9",
+      "0x7aEa2188414C6d22ce15b2b0b2870Bce69e5e5D5",
+      "0x09b043840cd2f32687ec6b63fb0412585de39822",
+      "0x12efda5e4d410c5da723ceb7e43942779e3fe49b",
+      "0x94d0bef156041af3ef0b9fec4784468e660045dd",
+      "0xaB568b1B49f8bE7488Ca1c0D5DdA6fF94691e4c8",
+      "0x88a8596e2B51512aab3867Cc895d7047E1D9ef7B",
+      "0x26d8da52e56de71194950689ccf74cd309761324",
+      "0x5013c0b3defd8f832d1b6dec750382946de5c13b"
+    ]
+  },
+  {
+    "name": "Capricorn",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1931864507590045696/yn7mxTi9_400x400.jpg",
+    "website": "https://capricorn.exchange/",
+    "description": "The premier liquidity venue on Monad.",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x6B5F564339DbAD6b780249827f2198a841FEB7F3",
+      "0x0136B6347509D386c6da3896162BEBaAF19e51c4",
+      "0xEd2850D3704a1a5BcB6158f27deDA3d6FF4C31D9",
+      "0x4C02af995BB1f574c9bf31F43ddc112414aE0Ac7",
+      "0xdac97b6a3951641B177283028A8f428332333071",
+      "0x830b22425257A752314A5f0902559164c84e44A4",
+      "0x53153392D0175D394D721CCF31173a49F7E6Ef53",
+      "0xB430EDD2b54cdB3B25703fb3342ca3a88663A04D",
+      "0xEcEB2CfcB38D1f469f55a3E5dc0C950Df8A465c3"
+    ]
+  },
+  {
+    "name": "Cashmere",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1551945866793164802/KmcIMByo_400x400.jpg",
+    "website": "https://cashmere.exchange",
+    "description": "Autonomous Monetary Infrastructure for stablecoins — a unified layer that powers zero-slippage omnichain transfers, yield agent, on/off ramps, privacy transfers directly on https://app.cashmere.exchange.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xD156fFB54871F4562744d6Be5d6321B5BffCa3B6"
+    ]
+  },
+  {
+    "name": "Chainlink",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1800426318099595264/N7yf_kOD_400x400.jpg",
+    "website": "https://chain.link/",
+    "description": "Chainlink is the standard for onchain finance, verifiable data, and cross-chain interoperability. Learn more by visiting chain.link.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x33566fE5976AAa420F3d5C64996641Fc3858CaDB",
+      "0xEd813D895457907399E41D36Ec0bE103E32148c8",
+      "0x2a954d493eE80BcC7cDeF56DB6fC6edC6758CA5d",
+      "0x81Bf4bbD9910F95c18cf661752bD9a07629fe191",
+      "0xA7cd3368eBC801df68812d46AB6b3F47d4BF37ea",
+      "0x900f68B165443A4aa1F8071471DFb8000df3bfF2",
+      "0x714de9941991c7Cec93efA6cB63469bD6bFE1258",
+      "0xF43deF45aCd1C1c54937937591dDA64b43DD87C2",
+      "0xcD22c0012480987F6F81F1099E74954B75666361",
+      "0xBb911c169033289187f70Af5c0DD8E6f643e4ADc",
+      "0xb0c0202E6d8b978f9b6FE6B5e50ebD6FD7A962a1",
+      "0x060728Ec2e1e132279EBa0a79b2ffFE26AbAD65C",
+      "0x92929c1b04C6b4AbD6c2C34111d447d972cACA71",
+      "0x3b126914ad2f884A68b8C182129109eF2Bf97ab7",
+      "0xEB58Fa36e5715fc1Bdb9959E0Ae01803B7432882",
+      "0xBAf3aaECB1A4f8468D88c74cD014a3550F204970",
+      "0xc1d4C3331635184fA4C3c22fb92211B2Ac9E0546",
+      "0xC6D6f57EFe5Ce2769aF0e0D8708477e4819F92d0",
+      "0x6156c406B7672b4720B7A2E637F32fc68E55930c",
+      "0x8fB6979CCB8Cbe1596Ad712955aF201e0A29c26f",
+      "0x3dDc1bAE752aaEe31b577bF844c799C349A1d6BD",
+      "0x14ef5938Cb0D1164516DD71fC656A8294570Ca7e",
+      "0xfDa103bb79FbB958eD270F828ca2506D046cAC91",
+      "0x91E70e5E0eAc9F07E3abd7B4b62173e6b67c30d8",
+      "0x1c747D909102bfCdb305C54bDdDBdA3eF588B1d0",
+      "0xDfc4441DBBeD5F2A743C001F722BD8d4f587C8fb",
+      "0xc40F902d11b11BF243283AF537A4Fc617344B2C7",
+      "0x18d19FECf754B2F16301B9Cd9A4F3d3A3540Aaa2",
+      "0x1B1414782B859871781bA3E4B0979b9ca57A0A04",
+      "0x3d21E2E680E2a60b440da427820aEe2391375EB7",
+      "0xC38c1843751941019EdE3B8E041EE1bD14575B44",
+      "0x7d12A857FB76396b3fF8749f6F832908E2DC55f5",
+      "0xf62D24B17181305B22E520fB14384eB86b9C6944",
+      "0x68bA3f3b52b17bFCc8cFB9cB97Df14D6A0f96E5E",
+      "0x3D160cBa91B35BC295295Cb790080E9be9A46811",
+      "0xF73F65C2DF4E1CB89f31DeE710A00627E6B9bbbC",
+      "0x5c266b5c655664d6c99a13fF0d7F1F7eaF4Ac9ba",
+      "0x44b9e53236b95Ca6Cfc1dAED893C5b312e596477",
+      "0xF29B907b292fb27e07f06331E4e92Ea7288a6001",
+      "0x24f29BB8ec47674F1A0a9011116c41F867a94337",
+      "0x921cB0E4f2397454240CcdB27596217CE4e65090",
+      "0x5658EC04E7e6EF42B1C567AafC33Cd92751E1730",
+      "0x3B59380FdCf2fd414F1675D76AF5F20FB92663a7",
+      "0xB5bE9cb264D299710F98c03f2604157E33E2c4cc",
+      "0x519dC0fBb6f4fa37F59Dc17CC60eF4d95cd8D001",
+      "0x23c377a8f4d153803a9D7869d56d0A4aEFdEeA93",
+      "0xb368d0CF937A6843fb68f1CD0056C835B4Cf3F70",
+      "0x638405174C766b9d1797860fDF696732921179F5",
+      "0x7422d308f0Aeb0c7816402Ff4E68078c2549435b",
+      "0x19d7FD9167597e0338dece5F3DE95f1BE61FAc40",
+      "0x1Bd7CEBABA5C2c40D44b83A08F42A3377447dDFe",
+      "0xd3f27362D951Cfb596242FFbA9c71E6c7d5d09AF",
+      "0x251eD64BD39e8fceB708b483D18Ee34bf4040aE8",
+      "0xB983b1b6f1Fc04030F9d8935DBBFd2a1239D00d9",
+      "0x68f23F7820B8528FBd1039B235923d8FB2590985",
+      "0xF007B6D353302A6C49D18C35809faa031E94eFbB",
+      "0x16F8008c3e89f62e5e2b909Ce70999370D38F4F2",
+      "0x10da0c6188A7d74d8556e1d6A193D58721e5E102",
+      "0xd447F67Dc94f234dFA1a3921C08330CecA06a1dC",
+      "0xE4DE4f111f6a015963589256A0EcC2F70Cb29BdA",
+      "0xad7AF5c6d78Ef5f4d3c4133593047d9E2A8BDa8d",
+      "0xBE1442Ec0a67D37D1e57c4940e0C0747cf7d55b9",
+      "0x69E075202802B5a90661AfDb4aDC117Eef8a59DF",
+      "0x097d4088e99c1a01a5713B079C898Fad852b9920",
+      "0xB7E7A36A0Fc6543C10f4F9B60E942F1b628f2a13",
+      "0xFe3165008F7FFfc27cc2649c18FfcbB959F0495a",
+      "0x31938934512dFFf3c410a6D07CeAF5F38B66BFee",
+      "0xC64012057A58b91bF42361c7D50bA36C0255cb73",
+      "0x8Cc589634A0B5959Fb29fc1111CFf26356b11918",
+      "0x5075Ea68c3D769723BC9CC23120A60e4026dD70F",
+      "0xa63564f2A626f69130C1CCA87f984351B26Cf2f1",
+      "0xCc973DAEf0A2d92BC99c21561b3FEa74DA033796",
+      "0xf5F15f188AbCb0d165D1Edb7f37F7d6fA2fCebec",
+      "0x449aeeE17b0447Af2D2Cdf3334EBF1e15C886Fb9",
+      "0x6b5902EABcE27C23FC97ea136504395b4d22C1FD",
+      "0x7bA2142854c5116D610AD2Eb45eB5435b875D08a",
+      "0xa16212CD5b330583B346167fA91E138d41AEe8CC",
+      "0xDfFa1693B3DDBE1A6a26c29B727e073a1D2A4Be5",
+      "0x1a1Be4c184923a6BFF8c27cfDf6ac8bDE4DE00FC",
+      "0x0087d34545e1A9a62051c023A31B2193C21Cbf4F",
+      "0x5A96Af6E7c9aA17901D9E2f00feafAFc7655B19F",
+      "0x4b1DFE1e642d8786Af6D19d63CEAf0D5475EDdF8",
+      "0x2D1Df1bD061AAc38C22407AD69d69bCC3C62edBD",
+      "0x1d6533DdC0E46514afbeAB55a013D6ded720307C",
+      "0x42dd36b9D6938dccff8Fe4E9770589aBa614FCBB",
+      "0x24b8BEAD860e19fA9650c349eC496eb4b09F7f9E",
+      "0xe6cd21b31948503dB54A07875999979722504B9A",
+      "0x4E14B7f0744a757F3c04Bfd7980721AEE3b7ea9F",
+      "0x29bEb7e730f09D33417357dbed020B549fdF7db4",
+      "0x8Aa871027BA54dc1a9c803456AD613668a643fB4",
+      "0x61dD33A34E47a181EE02e42eE0546a3DA808f1B4",
+      "0xFeccbf9C82Ff5231073580334DC605740309ebCe",
+      "0x979211Dfbc0738559B778a6a58a5b1bbbBe720f9",
+      "0xfd03e1bd18b11fA56c55582a91e8fc0bB0A1c27E"
+    ]
+  },
+  {
+    "name": "Chainlink CCIP",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1800426318099595264/N7yf_kOD_400x400.jpg",
+    "website": "https://chain.link/",
+    "description": "Chainlink is the standard for onchain finance, verifiable data, and cross-chain interoperability. Learn more by visiting chain.link.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x4AfC00570596d172595A4E38384289b880263006",
+      "0x99dFCa5d88f4D9C023531F4403966b8d61562AcD",
+      "0xF181489663b5b99af5C5a57310F1d66eEEEC2160",
+      "0xDdBC012B8a5C317b9611ee593fA49dE370BF950f",
+      "0x11ACd984DD680363117B310f6ebdf78fD6c0195f",
+      "0x4c1D9f81D59270ddc1c0f1A4D7C39264D9ADa379",
+      "0xb39B7D0cdd79B94B08b334965C1720be51A31986",
+      "0xCE78587FEADDefC30e36520C09fc3a333dd6eEf4",
+      "0xBad8b04ED03A1CEaC89e8328f4eA7148B2E6D642"
+    ]
+  },
+  {
+    "name": "Chronicle",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1501371292557185027/0XmX2Tp3_400x400.png",
+    "website": "https://chroniclelabs.org",
+    "description": "The verifiable data provider for onchain finance.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x55900781784cC88e10b53B400241a8B5099b1a58",
+      "0xaE9Ef5d8193348E484805683aA4026F4d410d9E9",
+      "0xECd09Ce60c069384D6B91656A841097F1181A59e",
+      "0x8644203113402C1D9CBe0A39064E467eE76e2fBC",
+      "0x7FC72F82B67aD3bbbaDA92b62d412AB284f910A6",
+      "0xcBA348Ee71970714cEBBC26C7e38baCeb0C6A597",
+      "0xa7f041Fb6AfFb962162Ff3f318cA184299e4eC58",
+      "0x7a5c9Bc685C16190Ac832a6bc232BC6C22e9ed18",
+      "0x8B9CB9999871423A549261B53e9cf87300e50349",
+      "0xCbec56397d82D353767911142aB2cBEB2F5e06ae",
+      "0x936a444C983347FFBfe3F26D1497CAbfA2BfE271",
+      "0xA3835b84BcaBF17C7509D09487E7B7169A82d64F",
+      "0xEe4631539c06aCC8c1f681C0b1b573FbC8506Da8",
+      "0x23035f3554c8EeC9d079276Cc4af0d2FED067992",
+      "0x43a05b07238d1f9814B55E145738AFdeEDACa68f",
+      "0x144a4B14115fcBe23408611a5307115a96ab5bA1",
+      "0xd52C49Ea370cDaa0E5912A98B3AAf3375768E49B",
+      "0xDa75F9d81dca1Ad7a2D3F628425c3736E2e7B685",
+      "0x46eA6F8Ad2F346801a346FB95E0e9E6106791291",
+      "0x812Aab12D9C323678C78d7EC6Aa76F4bc86f623a",
+      "0x8F9ad9205B442ACC5105Aac1F1efe5f09B194e1d",
+      "0x5B49FA5187F99DA89C644cd2C1c23ff3b1d8dd88",
+      "0x700EdC28DC93E72D76E8C1eA2Be0A50d60a4844D",
+      "0x83D794F01A3eDBdD92ae2f2EcC8e56b41eD7777c",
+      "0x109Bbc7056B5e808F8E64Fc71D12C89e654F688F",
+      "0xf8689D8A90cDB562ea2B83cecE80c8a551a931C6",
+      "0x847A305548462557945088c97074524d1Fe9d563",
+      "0xD4920c3Eba8c0E4824afe7B3737fACD7C1022234",
+      "0x418541FFD62bDB3078fb669cB9c18D45942d9C3d"
+    ]
+  },
+  {
+    "name": "Circle CCTP",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1719446730091962368/Bl01sQsB_400x400.png",
+    "website": "https://circle.com",
+    "description": "Building the Internet Financial Platform",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d",
+      "0x81D40F21F12A8F0E3252Bccb954D722d4c464B64",
+      "0xfd78EE919681417d192449715b2594ab58f5D002",
+      "0xec546b6B005471ECf012e5aF77FBeC07e0FD8f78"
+    ]
+  },
+  {
+    "name": "Clanker",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1953706842032324608/Arf6RRS3_400x400.jpg",
+    "website": "https://clanker.world/",
+    "description": "Clanker is an AI that launches crypto tokens for you. Give it a name and symbol, and it handles deployment, market creation, and fee sharing automatically.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xF9a0C289Eab6B571c6247094a853810987E5B26D",
+      "0xDe51a86D3b6EC9ac4756115D3744335Aa2c30144",
+      "0xe7D402A5BEd94E5c49Ac0639E80f784D06E2D397",
+      "0x654E7221fa51d4359ded21D524E3AfF18e93A507",
+      "0x8790d79283eB941c719b616CfD0Ef116D13C7683",
+      "0x3231D1ddfdC4Ad585cF1939FfEcd9c88b338Dbf2",
+      "0x46B77BaCFd712D79131F1AD7611794869483C353",
+      "0x94F802a9EFE4dd542FdBd77a25D9e69A6dC828Cc"
+    ]
+  },
+  {
+    "name": "Clober",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1679045925556355075/lvEiK0XY_400x400.jpg",
+    "website": "https://clober.io",
+    "description": "Clober is a fully on-chain CLOB DEX protocol with a gas-efficient matching engine optimized for on-chain execution.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6657d192273731C3cAc646cc82D5F28D0CBE8CCC",
+      "0x19b68a2b909D96c05B623050C276FBD457De8e83",
+      "0xe424c211e2Ed8a5B6d1C57FA493C41715568D238",
+      "0x7B58A24C5628881a141D630f101Db433D419B372",
+      "0xB09684f5486d1af80699BbC27f14dd5A905da873",
+      "0x54cd5332b1689b6506Ce089DA5651B1A814e9E7D",
+      "0xb1251BF43Bb7De76DE7e6CE7B64aF843dfc9d242",
+      "0x9050b0A12D92b8ba7369ecc87BcD04643Fa0CfDB"
+    ]
+  },
+  {
+    "name": "Covenant",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1760674458497654784/SeqF3eEq_400x400.jpg",
+    "website": "https://covenant.finance",
+    "description": "Covenant is a fully on-chain credit marketplace that enables the creation and funding of leverage against any collateral asset",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x11A7Ab0A9D7bD531DBcF0f0630BF7167F8F198f6",
+      "0xAB0f8aB1e67cc02A9D58fc27055292289B159094",
+      "0x6A5Aa3df89bA1C1f8B471c72159458D61a9447c2",
+      "0x9a369DF53EC62725c93f41B891e701BD88aFf2c8",
+      "0x5c1fb9a1232E87702897424eC0852D30B713bfD8"
+    ]
+  },
+  {
+    "name": "Curve Finance",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1220560374346461185/W1sQNVWo_400x400.jpg",
+    "website": "https://curve.finance",
+    "description": "Creating deep on-chain liquidity using advanced bonding curves.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8271e06E5887FE5ba05234f5315c19f3Ec90E8aD",
+      "0xe460dec242bc0A1a364c250a9D2F731d8D923650",
+      "0xFC687EFAFED297b765eDEcF8179c32195597C2df",
+      "0x845b942DeEF9BC20a39A8b34B23e8c33aC2921BF",
+      "0xC9459A955a885467f01Ccc531c51dBcC957993c0",
+      "0x46FEffb8Ed015250Cd48f9bf7F4a4584049Ca4aE",
+      "0x6E28493348446503db04A49621d8e6C9A40015FB",
+      "0x286182220E734AaC601282ba059de531d4BEAC1f",
+      "0xA4A2E7E11cBe5213B316E801D2172Ef10e566A96",
+      "0x2Fe4A238F6A3BD7fAA68e0B6951e3FAFdB2876Eb",
+      "0xBBbe22DEe69747e61f676cF50465b1bfbA4a4dD6",
+      "0xe7FBd704B938cB8fe26313C3464D4b7B7348c88C",
+      "0x5F870C2cf22ff829B5DC1Da09856B79dA6544f94",
+      "0x95249Dd40dDa3c0cbB4A7dd7D287E04aA68A3D4B",
+      "0x17c67C3A38F68cbc4dEC77Fd7378978971B6c271",
+      "0x7e595b3b77CC16680C30617b88E9b87F987Ac934",
+      "0x41D2c5128A7241EC1f7CE346B162C347C19548B7",
+      "0xbb8A5E91295131Ce07B6Bfe301C49bcD925A2902",
+      "0x193110Ce1542d7371e1515BD6A2E470fDefc310D",
+      "0xB2Be7692B07b640C9f2ee1187cee2fAec741F872",
+      "0x129578f94C253b8Bc903Bf2b73D07BF2583cc11d",
+      "0xFF5Cb29241F002fFeD2eAa224e3e996D24A6E8d1",
+      "0x2AF43209B366A4491CCe0A97C5a7B6059fd21295",
+      "0x4574921eb950d3Fd5B01562162EC566Cb8bc3648",
+      "0xe6dA14500f0b5783E2325F9C5a7eE5d99DA0fB42"
+    ]
+  },
+  {
+    "name": "Cycle Network",
+    "type": "Infrastructure",
+    "logo": "https://pbs.twimg.com/profile_images/1745373174735540224/egXcozCp_400x400.jpg",
+    "website": "https://www.cyclenetwork.io/",
+    "description": "Cycle Network is building a universal all-chain settlement layer and a bridgeless liquidity network for the entire blockchain ecosystem.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x647E77A1AF7c87688B974F20DB75eA36C28D033E",
+      "0xaD5cA27D8932114a9457d385FC0b88825c845960"
+    ]
+  },
+  {
+    "name": "DeBridge",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1894665537466040320/5vQrjq6M_400x400.jpg",
+    "website": "https://debridge.com/",
+    "description": "Trade any opportunity, ahead of the curve. For first-movers.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x663DC15D3C1aC63ff12E45Ab68FeA3F0a883C251",
+      "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
+      "0xE7351Fd770A37282b91D153Ee690B63579D6dd7f",
+      "0xeF4fB24aD0916217251F553c0596F8Edc630EB66"
+    ]
+  },
+  {
+    "name": "Definitive Finance",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1989507102352764928/AXdL2XHz_400x400.jpg",
+    "website": "https://definitive.fi",
+    "description": "Definitive Finance is a professional trading terminal delivering advanced on-chain execution and risk tooling for active traders on Monad.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xdeF00000cc0a125ba7962e8113d3B69786851736",
+      "0x0000000d1126e7651931461F31Be87712CD9E05C",
+      "0x000000005aE5f42270cDf0E41960840e7FB1b2dc"
+    ]
+  },
+  {
+    "name": "Dexalot",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1905272093492572160/3ilOLKT8_400x400.png",
+    "website": "https://app.dexalot.com/",
+    "description": "Dexalot is a decentralized exchange (DEX) for spot trading, powered by a fully on-chain central limit order book (CLOB).  Competitive prices, zero to minimal slippage and no fees.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x1FD108cf42A59c635bD4703b8DbC8a741ff834Be",
+      "0xC725229Aefeab5fAec9cc1667d79D9478e564a0C",
+      "0x3D3E4F0523500f95039D0Fe600ACf2ADE4b06eB9",
+      "0xA0421a4DB5bb7577f9bb9B577b5F600a642368be",
+      "0x246c87368580acd6E9ca46Bf112aD91978389634",
+      "0x170c15cb9887E6Adb097518104B174Df212bB190",
+      "0xa5C079C1986E2335d83fA2d7282e162958e515D5",
+      "0x06B82468100A3A7b0EAC77289f0D1ab920573B16",
+      "0x15764530c716cEFaD9Cbd2310D722704D03de875"
+    ]
+  },
+  {
+    "name": "Dirol",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1971111107335979008/da7R3pmO_400x400.jpg",
+    "website": "https://dex.dirol.io/",
+    "description": "Dirol is the all-in-one trading aggregator for the Monad ecosystem, designed to be a single gateway to everything in DeFi. We aggregate all token launches, launchpads, and DEX liquidity from muptile AMM's, Orderbooks, into one seamless platform, eliminating the need to jump between multiple dApps and interfaces.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x77E73c3fCd3FEDba383025CDe4a5b97733A34c2E",
+      "0xA82098c33c75A4A1e20e06f352732910C75C690D"
+    ]
+  },
+  {
+    "name": "Doppler",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1989072411757568001/hKlsQbpS_400x400.jpg",
+    "website": "https://www.doppler.lol/",
+    "description": "Create custom capital markets with efficient price discovery and maximum flexibility. ",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x5fbe931dc4b923a7abe4c47ad68d5bf9eda5b76d",
+      "0x8b4c7db9121fc885689c0a50d5a1429f15aec2a0",
+      "0xaa47d2977d622dbdfd33eef6a8276727c52eb4e5",
+      "0x580ca49389d83b019d07e17e99454f2f218e2dc0"
+    ]
+  },
+  {
+    "name": "Eisen",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1861248882824593408/h5CrU_s__400x400.jpg",
+    "website": "https://eisenfinance.com",
+    "description": "A multichain DEX & CEX aggregator—streamline every swap.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x787C474B8A86354d0F5f19FB599a5FC7662A265f",
+      "0xECE5E77f9A9846C4D69555Eb44E0CFF8B5F03F1e"
+    ]
+  },
+  {
+    "name": "Enjoyoors",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1846943911429697536/Km5JGs5b_400x400.jpg",
+    "website": "https://enjoyoors.xyz",
+    "description": "Enoyoors is a protocol that unlocks yield on any asset on any chain",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6B5E332387e8beC98C52F10A72952B17176B4f1b",
+      "0x71F60773885011cC0a61613078733b4738B38f35"
+    ]
+  },
+  {
+    "name": "Fastlane",
+    "type": "LST",
+    "logo": "https://pbs.twimg.com/profile_images/1935840734726270976/nnMo1axH_400x400.jpg",
+    "website": "https://www.shmonad.xyz/",
+    "description": "Fastlane launched shmonad, the first holistic LST on Monad and Atlas, the first MEV protocol for apps to capture the MEV their users create.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c",
+      "0x2DA28fedc4643c787CB5c5e84fa6AaDb596875E8"
+    ]
+  },
+  {
+    "name": "Fibrous",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1910332320067747840/SGkFXgaC_400x400.jpg",
+    "website": "https://fibrous.finance",
+    "description": "One place for best execution across chains.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x274602a953847d807231d2370072F5f4E4594B44"
+    ]
+  },
+  {
+    "name": "Flap",
+    "type": "DeFi",
+    "logo": "https://beta.flap.sh/_next/image?url=%2Flogo.png&w=1080&q=75&dpl=dpl_D8pNRVsFr6RF8LkbCB6nnUb1Rb4w",
+    "website": "https://flap.sh/monad",
+    "description": "The premier memecoin launchpad for trench warriors on Monad.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x30e8ee7b5881bf2E158A0514f2150aabe2c68b23",
+      "0xB88189aA1162850D75A1c1e16F837b7979994184",
+      "0x1C8847736521f5cD725dFB8f33c7c610826e7C42",
+      "0x57Fed6832F12150a77D5952b49190d9447aCB5ee"
+    ]
+  },
+  {
+    "name": "Fluffle",
+    "type": "Social",
+    "logo": "https://pbs.twimg.com/profile_images/1972672305336569856/JLjBcagi_400x400.jpg",
+    "website": "https://fluffle.world/",
+    "description": "Fluffle is the first hyper-gamified productivity platform that makes focus addictive. ",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8255DACD8A45f4aBE6dc821E6f7F3c92a8E22fBB",
+      "0x2eD99dbE114249B7611478d67818B399865FFc89",
+      "0x67f58f1faf78781b7eb90c457846e0f965bb1a2f"
+    ]
+  },
+  {
+    "name": "Garden",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1955253205832699904/83uUswbn_400x400.jpg",
+    "website": "https://garden.finance/",
+    "description": "Garden is transforming Bitcoin interoperability with its next-gen bridge. It is built by the renBTC team using an intents based architecture with trustless settlement, enabling cross-chain Bitcoin swaps in as little as 30 seconds with zero custody risk.\n\nIn its first year, Garden processed over $1 billion in volume—proving the market’s demand for seamless, cost-effective Bitcoin bridging solutions.\n\nNow, Garden is unlocking a new era of interoperability—supporting non-likewise assets, external liquidity, and a wallet-friendly API—to onboard the next wave of partners and users.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xE413743B51f3cC8b3ac24addf50D18fa138cB0Bb",
+      "0x5fA58e4E89c85B8d678Ade970bD6afD4311aF17E"
+    ]
+  },
+  {
+    "name": "Gas.zip",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1750310657680101376/HEtUyTZy_400x400.jpg",
+    "website": "https://gas.zip",
+    "description": "Instant liquidity bridging for over 350+ chains",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x9E22ebeC84c7e4C4bD6D4aE7FF6f4D436D6D8390",
+      "0x391E7C679d29bD940d63be94AD22A25d25b5A604",
+      "0x8C826F795466E39acbfF1BB4eEeB759609377ba1"
+    ]
+  },
+  {
+    "name": "Gearbox",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1737949216708739072/ISu5WSUS_400x400.jpg",
+    "website": "https://gearbox.finance/",
+    "description": "Gearbox delivers a seamless, all-in-one prime brokerage experience, right from your favorite wallet.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xF7f0a609BfAb9a0A98786951ef10e5FE26cC1E38",
+      "0x1cE2B1BE96a082b1b1539F80d5D8f82Ec06a0f9A",
+      "0xcCCCCcCc42B7DA9fdEc1761698Fb55fdD41CDF55",
+      "0xBcD875f0D62B9AA22481c81975F9AE1753Fc559A",
+      "0x0Bc03983Da93021a374C964A22b73865220Ce962",
+      "0x74A868AC479EE145029bB80827BB77F7B7c441cB",
+      "0x7D60CfaF7c2cec210638A5e46E4000894830C034",
+      "0x2fcbD02d5B1D52FC78d4c02890D7f4f47a459c33",
+      "0x2238eDf33a72860cDbaec5F83ec246Df9e85c8E2",
+      "0x81Cda0aB38d8Bd0732123Eb0e36C0C566d35DADD",
+      "0xF7533CDCE5A2F7BF78B6fbf4B05f04F45D10140B",
+      "0xA7dE2e941c8818E51D1Fd84111d8F71dcafa6C3B",
+      "0xbede127c14407b9c345f5d7fae5782ab8eaa33f3",
+      "0x0E535b7D073a93646512cEa18fa7e650CC2b17C4",
+      "0x59b2fd348e4Ade84ffEfDaf5fcdDa7276c8C5041",
+      "0x4115708Fc8fe6bB392De2e0C21c2C81dA2222394",
+      "0x93Cba8445b13a05287bFf90D882cbcB514D617b7",
+      "0x12c8faEdD62cF0C5d4D742E57B98737a9a3F5E0f",
+      "0x70F1753a765C4df582FFA3B8d96AB492714E8992",
+      "0xa7ED6dB5761613CaE7CaCfAAE9Dca07a77809F9d",
+      "0x847a05C22c7508C674342A95356Adf9b3a0e0D57",
+      "0x19Ca61E672d1c6105f609418bfDC784F92F4Ecf0",
+      "0xAe3Dd11e5a7f99eD4cba2768D4095a55fbF7841B",
+      "0x00aDE38841AB8c6e236E232041e43B41d74B8B45",
+      "0x81cb9eA2d59414Ab13ec0567EFB09767Ddbe897a",
+      "0xfB79b6713fe214B8748ED7b0db1f93E4f1aC9d29"
+    ]
+  },
+  {
+    "name": "HaHa Wallet",
+    "type": "Infrastructure",
+    "logo": "https://pbs.twimg.com/profile_images/1954195620006346752/644sSCzE_400x400.jpg",
+    "website": "https://www.haha.me/",
+    "description": "Native wallet with ultra-fast transactions, exclusive rewards, and discounts.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xbd2C0dc6521CD25A8bb3943f50B5Eec7A9d9a8a2",
+      "0x4631F923C3c470061A97e008ED9c33DA4349612c",
+      "0xfFf4baDfe0EB9731F5593fE7CEd5B1209055E640",
+      "0xA01A2488Cbe09156da4a78fA46483556CE41710a"
+    ]
+  },
+  {
+    "name": "Hyperlane",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1671589406816313345/wGzRPeEf_400x400.jpg",
+    "website": "https://hyperlane.xyz",
+    "description": "GMP interoperability to bridge, issue, swap, and more",
+    "monad_exclusive": false,
+    "contracts": []
+  },
+  {
+    "name": "KINETK",
+    "type": "AI",
+    "logo": "https://pbs.twimg.com/profile_images/1947607859702673408/hpZ89aya_400x400.jpg",
+    "website": "https://www.kinetk.ai/",
+    "description": "KINETK is building the IP infrastructure layer for the next generation of digital creativity, unlocking attribution, protection, and capital for creators. Through the combination of proprietary invisible watermarking, agentic AI detection and tracking, and on-chain registration, KINETK is providing the tools that will underpin the future data models of the digital landscape.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xD057B63f5E69CF1B929b356b579Cba08D7688048"
+    ]
+  },
+  {
+    "name": "Kinic AI Memory Agent",
+    "type": "AI",
+    "logo": "https://cdn.prod.website-files.com/6712749157ea3bf4a781f309/671bbee00d9198b08a63cb40_kinic-logo.svg",
+    "website": "https://kinicmemory.com",
+    "description": "AI-powered memory system combining Kinic/Internet Computer for semantic storage with Monad blockchain for transparent metadata logging and audit trails. Features Claude AI integration for intelligent context-aware responses.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xEB5B78Fa81cFEA1a46D46B3a42814F5A68038548"
+    ]
+  },
+  {
+    "name": "Kintsu",
+    "type": "LST",
+    "logo": "https://pbs.twimg.com/profile_images/1984001421960704000/UpI70-s4_400x400.jpg",
+    "website": "https://kintsu.xyz",
+    "description": "Composable liquid staking protocol that powers decentralized validator curation, governed by the Kintsu DAO.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xA3227C5969757783154C60bF0bC1944180ed81B9",
+      "0xf16f96c342913575e46cff1bb827533c0b285138"
+    ]
+  },
+  {
+    "name": "Kodeus",
+    "type": "AI",
+    "logo": "https://arweave.net/MS-KY8qBeQ0KHJvez0HgkkrXCN48_ZnlUWrzIQJil2k",
+    "website": "https://kodeus.ai",
+    "description": "Kodeus is the Internet's Agent Layer where users create programmable and monetizable agents that act, settle and prove autonomously",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x3d3c1Db86989eD5196358eE03e2F1258EA183dCB",
+      "0xa0371d51C086f846Bd02c331DD31cc510645332e",
+      "0xa2c272C0D4fd83587ce3A4e81FA3Ad0eB9d63F9D"
+    ]
+  },
+  {
+    "name": "Kuru",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1950962142917619714/R7Cj_qk7_400x400.jpg",
+    "website": "https://kuru.io",
+    "description": "Kuru is the all-in-one trading hub for Monad. Trade any spot asset with our smart aggregator and trading terminal. Deploy liquidity on our hybrid AMM-orderbook. Launch a new token in seconds.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xb3e6778480b2E488385E8205eA05E20060B813cb",
+      "0x465D06d4521ae9Ce724E0c182Daad5D8a2Ff7040",
+      "0xd651346d7c789536ebf06dc72aE3C8502cd695CC",
+      "0x2A68ba1833cDf93fa9Da1EEbd7F46242aD8E90c5",
+      "0x974E61BBa9C4704E8Bcc1923fdC3527B41323FAA",
+      "0xe29309e308af3EE3B1a414E97c37A58509f27D1E"
+    ]
+  },
+  {
+    "name": "KyberSwap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1641706567014940672/UFuWgdxn_400x400.jpg",
+    "website": "https://kyberswap.com/",
+    "description": "KyberSwap is a decentralized trading solution that helps users find the best token swap rates by routing trades through multiple DEXs and other liquidity sources across multiple chains.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6131B5fae19EA4f9D964eAc0408E4408b66337b5",
+      "0xcab2FA2eeab7065B45CBcF6E3936dDE2506b4f6C",
+      "0x89C91686948C3Bc9A5bDF7A2A773ea71530a233e",
+      "0x4445520306c9C70952bDFEc28F3989f53d9f80C4"
+    ]
+  },
+  {
+    "name": "LFJ",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1852261646409809920/-ZwSUHqA_400x400.jpg",
+    "website": "https://lfj.gg/",
+    "description": "The most CRACKED fee machine in crypto. Ultrasound DLMM with hyper-efficient trade flow capture.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xb43120c4745967fa9b93E79C149E66B0f2D6Fe0c",
+      "0x18556DA13313f3532c54711497A8FedAC273220E",
+      "0x9A550a522BBaDFB69019b0432800Ed17855A51C3",
+      "0x3A8E1Be95467690F7C592B596e42d11b3710c633",
+      "0x6124086B90AB910038E607aa1BDD67b284C31c98",
+      "0xA5c68C9E55Dde3505e60c4B5eAe411e2977dfB35",
+      "0x7ac3Dd4B5A3F7013116D8a28f0579a678282EA5c",
+      "0xDbeeB3FB3e864e490e71b1d5c86c3de683cA4626",
+      "0x45A62B090DF48243F12A21897e7ed91863E2c86b",
+      "0xF8155BcA49576B54018311C6129bdA088605B88b",
+      "0xF780668669C193B5D2Cf22B8420473fA1E3Ee3D1",
+      "0xe32D45C2B1c17a0fE0De76f1ebFA7c44B7810034",
+      "0x4faCe5b0EF2757Ceb9151D14C036A1135931C70E",
+      "0xf57B8a91F775B01d53450D7Cb4D2A99Ba989fd19",
+      "0xe70d21aD211DB6DCD3f54B9804A1b64BB21b17B1",
+      "0x371c7ec6d8039ff7933a2aa28eb827ffe1f52f07"
+    ]
+  },
+  {
+    "name": "LayerZero",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1779646801605242880/FrFssPAQ_400x400.jpg",
+    "website": "https://layerzero.network",
+    "description": "Powering the Chain-Agnostic Future",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6F475642a6e85809B1c36Fa62763669b1b48DD5B",
+      "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
+      "0x4208D6E27538189bB48E603D6123A94b8Abe0A0b",
+      "0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842",
+      "0xC39161c743D0307EB9BCc9FEF03eeb9Dc4802de7",
+      "0xe1844c5D63a9543023008D332Bd3d2e6f1FE1043",
+      "0x41Bdb4aa4A63a5b2Efc531858d3118392B1A1C3d",
+      "0xc1ce56b2099ca68720592583c7984cab4b6d7e7a"
+    ]
+  },
+  {
+    "name": "LeverUp",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1963940143171346433/mefOgn9M_400x400.jpg",
+    "website": "https://leverup.xyz",
+    "description": "LeverUp is a next-gen perps DEX with LP-free trading, deep liquidity, and up to 1001x leverage.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xea1b8E4aB7f14F7dCA68c5B214303B13078FC5ec",
+      "0xFD44B35139Ae53FFF7d8F2A9869c503D987f00d1",
+      "0x91b81bfbe3A747230F0529Aa28d8b2Bc898E6D56",
+      "0x135951057cfcccA7E8ef87ee41318D670f723F68",
+      "0xbF52cED429C3901AfA4BBF25849269eF7A4ad105"
+    ]
+  },
+  {
+    "name": "Levr Bet",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1836024387042004992/YKdDMkOG_400x400.jpg",
+    "website": "https://www.levr.bet/",
+    "description": "Decentralized Leveraged Sports Betting",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8e334460192926576ccD04271190c9E9e5916560"
+    ]
+  },
+  {
+    "name": "Li.Fi",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1940673908946120704/ZkHt9ssN_400x400.png",
+    "website": "https://li.fi/",
+    "description": "One API for seamless swaps, bridging and Zaps across EVM and Solana.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37"
+    ]
+  },
+  {
+    "name": "M0narch",
+    "type": "Gaming",
+    "logo": "https://m0narch.xyz/logo.jpg",
+    "website": "https://m0narch.xyz",
+    "description": "M0narch is provably fair, fully on‑chain iGaming platform",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x5B159027C1BcFDADd11CB5b44519251DbADb3749",
+      "0x266b1540d35DB5f64569Fe2d7db79EeC2ACF67dB",
+      "0x79575d8787b184841fD9eB28AAee2971646259cE",
+      "0xbB053a8CE778D8492Db5079aC36FfA99Bde92aBc",
+      "0x446012177a183adc281Df23987c21B0F83Fb7e97"
+    ]
+  },
+  {
+    "name": "LootGO",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1947490514921488384/TLSJg7Z5_400x400.jpg",
+    "website": "https://lootgo.app",
+    "description": "LootGO is a walk-to-earn mobile app that turns your steps into a real-world crypto treasure hunt. Think: Pokémon GO, but with crypto rewards.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x3E1fC8371bf6dCEFfd829ae2134005a4AE890b71"
+    ]
+  },
+  {
+    "name": "LumiterraGame",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1667436896480563200/8YPmbLbv_400x400.png",
+    "website": "https://lumiterra.net/",
+    "description": "Lumiterra is an open-world game where you team up with an AI smart-companion that learns your playstyle, helps you win battles, farm faster, and explore smarter",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x4bd7aB4f4251f6A20E8c64D24F3A2f89F47D80B9",
+      "0x8f28E18039c37cdB4389E6dcb8703966fb9480A8"
+    ]
+  },
+  {
+    "name": "Mace",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1876861581763764224/3Z3F9Cef_400x400.jpg",
+    "website": "https://www.mace.ag/",
+    "description": "The smartest DEX aggregator on Monad",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6F05a0746a8CB5c7DE5aF1568C8d020DBB521B23",
+      "0x70ca11a8bb062EF86e6E662b58aE3cAEeF1d66e5",
+      "0x60672942Dd9BEAf2D4980892A1B8001B5178149f",
+      "0x8A64d063Dc534a160914da4Dc86804be5e8DE98b",
+      "0x73590e38F40F799eDb3AfE3142c0Ea891F393D9D",
+      "0x0E89C6d18933E2dA3a5C56B0727113B2247AC847",
+      "0x59966aDd989Bb2b8A528B796a81FB7e593072529",
+      "0xb346fbd2Ba963a1C3B00946c733e9f0d5CE7AEeC",
+      "0xaA318069cEe0E16E25B8aA34C27Ac20C4DE16fC2",
+      "0x39C361d267853A43f4e6237291CeA0701C426aBe",
+      "0x7D120C4FCcBd620b398E04f9147271cF5cAC587C",
+      "0xA24bE4225DdA623E4Db49Ed12c80AaE583447482",
+      "0x42A3ED3010D38daB622b9e135df724AB4a813cd7",
+      "0xC1d16c871d816Cb2400243dC7A61ed4E9137FbEb",
+      "0xC6B6b9E8eB8b3cf2Cecd8Ff536A9E1599D8Ab426",
+      "0x9D282092C60303BA8Fc219501CfEdAFAFa290A64",
+      "0x5C968a45404e55Ffa5DA393fe7db96f244792707",
+      "0x057F554fe1558D2910e5e0865d9177E8EBB60197"
+    ]
+  },
+  {
+    "name": "Madhouse",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1978014535148535808/LYuLF9u0_400x400.jpg",
+    "website": "https://madhouse.ag/",
+    "description": "Experience lightning-fast 10,000 tps on Monad with Madhouse aggregator. Trade with speed, high liquidity, and madness.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6017684Bea9Cb6e9874fC6DBA4438271eBF9F5DA"
+    ]
+  },
+  {
+    "name": "Magma",
+    "type": "LST",
+    "logo": "https://pbs.twimg.com/profile_images/1798840544887787520/OWxSEpYX_400x400.jpg",
+    "website": "https://www.magmastaking.xyz/",
+    "description": "Native liquid staking and MEV, powered by the fastest block engine in crypto.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081"
+    ]
+  },
+  {
+    "name": "Matcha",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1936106079877844992/t_kZCRae_400x400.jpg",
+    "website": "https://matcha.xyz/",
+    "description": "Matcha provides optimal trade execution and helps you discover new tokens by aggregating hundreds of DEXs and private market makers. Get complete token coverage, gasless swaps, and deep liquidity on Monad and 15 other chains with unbeatable pricing on any token pair.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x0000000000001fF3684f28c67538d4D072C22734",
+      "0x478cF28Fd1Ba92a6afd04F44b05833F6dF7f1486",
+      "0xFB36B62145A4B272bc804e5E1b41ddbf4BFF4CF4",
+      "0xb2376d1183829f444e0ffE9EF1FFaf1b483B84F3",
+      "0xb40e9939bb598C38665A5C99c68020EEB8Cf49FB"
+    ]
+  },
+  {
+    "name": "Mayan",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1992936326153244672/Qqu1LGXS_400x400.jpg",
+    "website": "https://mayan.finance/",
+    "description": "Mayan is a lightning-fast, intent-based cross-chain swap protocol that makes transfers seamless, instant, and cost-effective. Move any asset directly into Monad through our simple swap interface or integrate Mayan’s SDK and widget for seamless cross-chain liquidity.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x337685fdaB40D39bd02028545a4FfA7D287cC3E2",
+      "0xC1062b7C5Dc8E4b1Df9F200fe360cDc0eD6e7741",
+      "0x598400bA0d8BA9C3b57ad424A68183f1D17c7e56"
+    ]
+  },
+  {
+    "name": "Mintpad",
+    "type": "NFT",
+    "logo": "https://pbs.twimg.com/profile_images/1780703842142941184/bcu1af6z_400x400.jpg",
+    "website": "https://mintpad.co/",
+    "description": "Something like this ok - Mintpad is the easiest way to launch NFTs on any EVM chain — completely free for creators. Upload your art, customize your mint page, and deploy fully-owned smart contracts in minutes with zero coding required. Mintpad handles all the technical heavy lifting so you can focus on creating and building your community. It’s the fastest, simplest, and most accessible way for anyone to launch an NFT collection.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xaaae0243007AA3000000d8e8bEeF0a944A0d3900"
+    ]
+  },
+  {
+    "name": "Mona Trading Bot",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1954134808667545600/W4Af_hDl_400x400.jpg",
+    "website": "https://t.me/monatradebot",
+    "description": "Fastest trading bot built on Monad",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x27A6c2E8aE9E7f96040394a1F8fE2A202cE0E599",
+      "0x7e75D7EB235703D8AcbD71382bF2F344fB23aB5b",
+      "0x95dEf69A01962f0Cb24e2C5DAA1Fa5126Beea95D",
+      "0x50aDc49F643F06888A8950dD172Ae48221e49a38",
+      "0x09ec7D8D3065097D5859539ED4590Dd76c0C77e0"
+    ]
+  },
+  {
+    "name": "Monorail",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1964025665105137664/rny-s1Dq_400x400.jpg",
+    "website": "https://monorail.xyz",
+    "description": "The best swap aggregator on Monad",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xa68a7f0601effdc65c64d9c47ca1b18d96b4352c"
+    ]
+  },
+  {
+    "name": "Mu Protocol",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1834816886292508672/VDkHAG2v_400x400.jpg",
+    "website": "https://mudigital.net/",
+    "description": "The Mu Digital protocol provides DeFi users with access to a diversified pool of USD-denominated, principal-protected RWAs through a dual token structure comprising of a safe yield token and a high yield token.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x4917a5ec9fCb5e10f47CBB197aBe6aB63be81fE8",
+      "0x336D414754967C6682B5A665C7DAF6F1409E63e8",
+      "0x9c82eB49B51F7Dc61e22Ff347931CA32aDc6cd90",
+      "0x00A927d9d8af27d06C4e2C3abb5b88b0E1766470",
+      "0x7B14860eCd88fb65A22A1d259D1248BF199FB47f",
+      "0xeF1776eD00e8f9Fe783e269d10676C7820465461",
+      "0xF3CDC00ccA19F336b1c1B4Bd684A949124a93Ea7",
+      "0xB55F4F4BBB466f9C022d3edF4B584c30Eb624113",
+      "0x8B9670C5E4D9F1C14f1F9fe625Dd099924aD4D4f",
+      "0x74AE87E5CE997B73Acfac85a3CE5570475D6B46B",
+      "0xe64730de04aeAf8d38925825D77D7a4c00340c89",
+      "0xe5f8Ec544310D5ae79DA0F921D01ce80fFD528eB",
+      "0x35F73a069554bb11d73307564265451b88B3e3b6",
+      "0x345E3ff3c551D1ad33A7294f405084b9863B9aae",
+      "0x3E0Ff06afCF1011c91A5063ca57f2Fcc54f7E862",
+      "0xd91C46C66c56e391f562885B1CF279b838863eda",
+      "0x319817781134B450B3A7C672243Cc701BFCaB44E",
+      "0xEDB2d57678440AD5bBE2213695B2ABEB754b72F7",
+      "0x9d839E0A6a86b05643b4811dE06ef09985EbBaef",
+      "0x0b4c9Dd5A3ecc14225d9b895716a65e4A7aD3fEc",
+      "0x7c28385Ee6cAd71a4C7F747f302582170a7B93BE",
+      "0xD4dF076285F36b8C996Fc5f2DC1f886f23a64229"
+    ]
+  },
+  {
+    "name": "NFTs2Me",
+    "type": "NFT",
+    "logo": "https://pbs.twimg.com/profile_images/1626191411384053761/NoRNmw9L_400x400.png",
+    "website": "https://nfts2me.com/",
+    "description": "NFTs2Me is a user-friendly comprehensive platform to create, deploy and manage your NFT collection on Monad, 100% free.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x00000000001594C61dD8a6804da9AB58eD2483ce"
+    ]
+  },
+  {
+    "name": "Nad.fun",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1827607782356619264/Owr-840k_400x400.jpg",
+    "website": "https://nad.fun",
+    "description": "Launch, trade and predict on Monad",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xAd8887348E5d5d479156c851F4F4778e83a1DFE3",
+      "0x65fDa572628c1D3F55B9e9E66e6e8a61c53cfF7c",
+      "0x3Be9198208c198e2a4dab9A575764C8468DC83c6",
+      "0x4ac5Fd82B91A10de7f91343DDCca7a2541d3F509",
+      "0x46895ee48Fb1D750A81562fd6019B37F21d7FD52",
+      "0x42e75B4B96d7000E7Da1e0c729Cec8d2049B9731",
+      "0xb0bAaCE23aC7cbd25211134a0B47ad70a9D42FA4",
+      "0x6F6B8F1a20703309951a5127c45B49b1CD981A22",
+      "0xA7283d07812a02AFB7C09B60f8896bCEA3F90aCE",
+      "0xAebe5522749b65eaE7b2A35c593145CC3128b515",
+      "0xCD68F7c0668B72Ab943E09Ff4Dbf53Da64b8a8c2",
+      "0x095ACd3d26DD09c8E26Ab864c8717a39fE61F320",
+      "0x0B79d71AE99528D1dB24A4148b5f4F865cc2b137",
+      "0xD5eE94894f3C86952AF792e1a03B1699c08b8c73",
+      "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea",
+      "0x7f64ccFeb3E3Afd7691ea0ef404E947786cefae8"
+    ]
+  },
+  {
+    "name": "Nar.bet",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1988147564227764224/MnPg-Spe_400x400.jpg",
+    "website": "https://nar.bet",
+    "description": "Nar.Bet is a derivative project of Narwhal Finance, built exclusively on Monad, delivering the first fully on-chain, provably fair betting experience that is gamified, social, and community-driven.",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x71dc4a726C92E6bf506F2Afc2Cee8B63A89B29EC",
+      "0xa7f902847a16F1CDbF043c0653865D40e6695de5",
+      "0xDA18dC7bb27Ca2056Fa3cA3da3973218Dc18F8e3",
+      "0x8baecE06d825d36b52cb588960aE707d6C76a54C",
+      "0xe3C0B41413Bc9913E0ace43a64637EF6C4e39F97",
+      "0x1CE656bD09a59A59513c4460220031d49038739e",
+      "0xf970b3C6A1bd7745A07B317543EA999e4E98666c",
+      "0x681D2C159EE77f660F5081a3c193fb9613b624C0",
+      "0x39AA4ECB48c52A018B2a1A700B89C4912FC39967",
+      "0xBEAaFcc7648354a0722350378bF2A295B9b946A8",
+      "0xbB1b4eE5D22ca19faa5aA9A55Caf4abAEd14607B",
+      "0x11B83A467AbFF4c466294af94B99ACEF3D85929d",
+      "0xFfbfB423dE2a5305004aeA3bdF6bD4917E87A962",
+      "0xdE5C871Fb0626562E9Acecc3c5b0EB12C298d8BC",
+      "0xEeBB73F7B52cD86ABc76e1fce2b5a38A684BCacc",
+      "0x0badb8f24327074CF94d6398E1B722e201c0BBf0",
+      "0x33F906D6c6aA65fb3055f2028dc394033C3310F3",
+      "0xBF3727f9aee1140870AF3303fba52537536F8e5D",
+      "0x49a3F93deDca36c7FA5Af695e89eEa0f03a1A11a",
+      "0xf485d6F84537bdf3A2096508652F9a6876975A8C",
+      "0xbF34070fEEF2063277626904F7BF736D70826604",
+      "0xb0279eB0cD894f9964c1945D9543FD6fc5C929fE",
+      "0xB3aFCc826F9dBF2A1a9F78a2ddDCD12517589267",
+      "0xAC55756556df38D9Be82AaDd31ac3849EC7826E2",
+      "0xb82360d08784f0Ff24A740ADaD6b1AC2391C8D57",
+      "0x0B1E533e33f9E82849E71fb5c0a33F38462D5eD4",
+      "0x843D62ad75F5d0b383f8520e23d19174b7961b8E",
+      "0xd6F08aF222C8aa69F99B6099F93C6d96897d378f",
+      "0x5859E2926750F3981f95bbA16b86d8e69cf4334B",
+      "0x3014d056Db789984552084Db359D7C56A620549b",
+      "0xb86A1955E96147665d7bdd70E50bD6Af38E086d1",
+      "0x8261A173DC96e206b8D8621ca1231a3E7bcB851E",
+      "0x4A050DD00c08856cc3d7C5BD152E4e601ffDaa35",
+      "0xb9e0b5447B92eb5CF246693F7b533d5c84AA8dC5",
+      "0xbbE3FA39912355C49Aa3ccdD02C51d989Fb33E79"
+    ]
+  },
+  {
+    "name": "Narwhal Finance",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1988146944473182208/89x23JI6_400x400.jpg",
+    "website": "https://narwhal.finance/",
+    "description": "Narwhal offers a distinctive trading experience with synthetic leverage and no order books or liquidity for each pair. The PnL calculation occurs in smart contracts and is settled against NLP for a secure, transparent process. This streamlines trading and provides a unique opportunity for leverage-based trading.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x3556d16519e3407AD43d5d7b3011bB095553d77a",
+      "0xfbc1cf329aD241352e777aB7BC17962452B87949",
+      "0x5c39f9739c123e64535F6250b256964Bc20c52f1",
+      "0xE22FB1f1bB003759FAcED645458B8b8ee262828d",
+      "0xb412A5d72c203Df308624e435659c9F70b6960aA"
+    ]
+  },
+  {
+    "name": "Neverland",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1993662956098232320/UcnsahQh_400x400.jpg",
+    "website": "https://neverland.money",
+    "description": "Neverland is a Monad-native decentralized lending protocol built on the Aave V3 framework, reimagining DeFi incentives through self-repaying loans, flexible NFT-based veToken governance, and automated yield strategies. It redistributes 100% of protocol revenue back to the community through governance-directed rewards, liquidity incentives, and deflationary buybacks and burns.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x73A78AFa04b629e22db3BEC357bfc4a8B4f149DF",
+      "0x80F00661b13CC5F6ccd3885bE7b4C9c67545D585",
+      "0xe3B56AAD3c21531055f39e73A51E8ff29DAAD049",
+      "0x49D75170F55C964dfdd6726c74fdEDEe75553A0f",
+      "0xD0CCDe10CAcd12f1c839Db6400B82a82ab90fa9B",
+      "0xfd0b6b6F736376F7B99ee989c749007c7757fDba",
+      "0x193672B2454850EE247435E365a87F7cb857a0f7",
+      "0x67B7178105D3715214E1F187C20CDd20B708F443",
+      "0xE7D17A88C66b4ED0b73872937cdC5e081C118DcD",
+      "0xE0B05346Fa8F57C2C634Ee1D53Ace20806858c01",
+      "0xc8a6A884B47ca0699A9dd76d5B8d1D3D21A8d94b",
+      "0x4de9DB60667Eb48A1Bf5c556BbA79058c44e34c2",
+      "0x44d2575191306Da86C488Bf86872Ca6D35489E4A",
+      "0x427B9008A254799aA3ac1d5Cc1DC2920dA3ad3Cf",
+      "0x4AD738afaC73f32F1e5F1898BCA150d4A52C88Db",
+      "0xdcF1Dcb529fE2C61bf8Bbb10eB8b5ae843882dC5",
+      "0x4c505f18C39Ef5881bCb5eBFBDd89E607ea2185d",
+      "0x09bD1E4bc6F035D5025D0e86a9b24a7fC9F1125B",
+      "0xb00E2D557cFCF73A3c6D9Fe98332290fac7546e4",
+      "0x9B4528918159e1ae937740051Fb69bcD4E164cc3",
+      "0x94bbA11004B9877d13bb5E1aE29319b6f7bDEdD4",
+      "0x395118096F0Ef19D7958Ad8538ecee9685B94eb2",
+      "0xbeA2124aE6d8225c491A85db16c419dcDC62159d",
+      "0xA02c3E9d0b9deC0A7F53908742af141Af4EF45b5",
+      "0x936C7E76905c83Edc12F8A5ca993a6609D8bBAA2",
+      "0xD0fd2Cf7F6CEff4F96B1161F5E995D5843326154",
+      "0x81b19837295a2b4b1f6E0B2eaA239999294374E4",
+      "0x3acA285b9F57832fF55f1e6835966890845c1526",
+      "0x38648958836eA88b368b4ac23b86Ad44B0fe7508",
+      "0x7491E87eed26418ff67422169a7608E67d691978",
+      "0xb26FB5e35f6527d6f878F7784EA71774595B249C",
+      "0x8911Db480C1c0c1E06f17C2Bc76b26D861e40D47",
+      "0x81242ADa455D766b5032EB4abf9baEaA49077450",
+      "0x0733e79171dd5A5E8aF41E387c6299bCfE6a7e55",
+      "0x800409dBd7157813BB76501c30e04596Cc478f25",
+      "0xAD96C3dffCD6374294e2573A7fBBA96097CC8d7c",
+      "0x4522144959Afee1CAe8aa553b6a5cB81E111A4DA",
+      "0xBB4738D05AD1b3Da57a4881baE62Ce9bb1eEeD6C",
+      "0x3875cdF0d2B4445B763B7FCAC5d28Db2ad6D30e7",
+      "0x57ea245cCbFAb074baBb9d01d1F0c60525E52cec",
+      "0x6aD1EcdA817ECB7696D21f6e600C7ec44AcFB1e6",
+      "0x394060Ee4cf4781F5ff6bCf471426D97A11977fA",
+      "0xff20ac10eb808B1e31F5CfCa58D80eDE2Ba71c43",
+      "0x1df0F25344D29F541a53502a96DfeD3066D40b0A",
+      "0x794CCdb375Ab08C340528a71Ba433a9016c657A5",
+      "0x49f745b5265b6CA695E60e89dc50FD36edD252AB",
+      "0xc9Fe3Db9b14A538FaB2eeBa33a8FeaB6ED7DdCeb",
+      "0xe82f2fa836BC5DB42a36C66027c0113BcAA28143",
+      "0x95AF995C9dcB1b6cFFEe6d81631dab5527884370",
+      "0x6400650cED1eD7179143D40b4431c3cC8c068D90",
+      "0xc91BA13910b358E0De6510D4e2F3AFDaf6395538",
+      "0xc8B7b87EB4a4B404a421bD3a1491a689A0be8611"
+    ]
+  },
+  {
+    "name": "OctoSwap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1881835000024231936/Fb3P06s-_400x400.jpg",
+    "website": "https://octo.exchange/",
+    "description": " OctoSwap unites the strengths of both classic and concentrated AMMs with an advanced smart router, making it the premier liquidity hub on Monad for efficient liquidity and execution. ",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xCe104732685B9D7b2F07A09d828F6b19786cdA32",
+      "0x60fd5Aa15Debd5ffdEfB5129FD9FD8A34d80d608",
+      "0x30Db57A29ACf3641dfc3885AF2e5f1F5A408D9CB",
+      "0xBfd2cf709A17c4eEE8DaaF3B96E134408881259e",
+      "0xF27Ba2b4ee5580Cb2A14FDF98CB981FF0ae149F4",
+      "0x2Ff18d8Ca8447DB19392AA3e27DCB640CEe83882",
+      "0x16eb676BbBe51EB6E4E9DDF57BfBEe0537aA4d7B",
+      "0x241BF19641839b249E8174Bd22FACd3d3ac0642A"
+    ]
+  },
+  {
+    "name": "OrbiterFinance",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1880886737221664768/_uBH9pgt_400x400.jpg",
+    "website": "https://orbiter.finance",
+    "description": "Bridge and swap crypto assets quickly, affordably, and securely across Arbitrum, Base, Optimism, Solana, BNB Chain, Polygon, Ethereum, and more blockchain ecosystems with Orbiter.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x70f6060fc8b01b56869feba8361df468f98c2900"
+    ]
+  },
+  {
+    "name": "Orochi",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1877208842834161666/DosXGKCB_400x400.jpg",
+    "website": "https://orochi.network/",
+    "description": "Orochi Network is a Verifiable Data Infrastructure designed to ensure data integrity and privacy through advanced cryptographic techniques.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x78291455bf33aA5437f9D69Ff63E0B1C09833429"
+    ]
+  },
+  {
+    "name": "PancakeSwap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1992213522940571648/yEcd7vsj_400x400.jpg",
+    "website": "https://pancakeswap.finance/?chain=monad",
+    "description": "Trade and earn crypto on the all-in-one decentralized exchange. Enjoy low fees, high liquidity, and a user-friendly interface.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x02a84c1b3BBD7401a5f7fa98a384EBC70bB5749E",
+      "0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9",
+      "0x41ff9AA7e16B8B1a8a8dc4f0eFacd93D02d071c9",
+      "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865",
+      "0x1b81D678ffb9C0263b24A97847620C99d213eB14",
+      "0xb099b459887bC759dBF0293E12D3DFcD0C456cff",
+      "0x46A15B0b27311cedF172AB29E4f4766fbE7F4364",
+      "0xac1cE734566f390A94b00eb9bf561c2625BF44ea",
+      "0x3095eC7D29b588283baB3184fae4dECd54D5D811",
+      "0xbC203d7f83677c7ed3F7acEc959963E7F4ECC5C2",
+      "0x9a489505a00cE272eAa5e07Dba6491314CaE3796",
+      "0xB048Bbc1Ee6b733FFfCFb9e9CeF7375518e25997",
+      "0x21114915Ac6d5A2e156931e20B20b038dEd0Be7C",
+      "0x77b482D9A4E391d682C857C630B8d869FdeE5c44",
+      "0x4c650FB471fe4e0f476fD3437C3411B1122c4e3B",
+      "0xfcB76dfDf9c79AE5d334C0E1901449c8A893DF22"
+    ]
+  },
+  {
+    "name": "Peridot",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1967990362242203649/oELnCnhK_400x400.jpg",
+    "website": "https://peridot.finance",
+    "description": "Peridot allows users to earn interest on your crypto and borrow funds without selling, all with smart, fair rates across multiple blockchains.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x96650BebC549456F253974c11Fc6cBE28172A2d2",
+      "0x42D5B37CD3682eDD0a3dBb242C579bDCB108f47C",
+      "0x81C0533c8132Bc20c3A53f599925AB01c7dA2B3A",
+      "0x6D208789f0a978aF789A3C8Ba515749598940716",
+      "0x1FB287E1c4F7B4c6b511f4d190523814593Ad84e"
+    ]
+  },
+  {
+    "name": "PingMe",
+    "type": "Payments",
+    "logo": "https://pbs.twimg.com/profile_images/1985754835460005888/UiqxXJjA_400x400.jpg",
+    "website": "https://www.pingme.xyz",
+    "description": "Making stablecoin payment as simple as sending a message",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x3de0E31A0a9d885bF98ea1512188e06F70D507B2",
+      "0x2a217B43b138e36979f59999776585ed6Bb27542",
+      "0x32F62bDC2BE3E1B1C0265143831155253cd5A248"
+    ]
+  },
+  {
+    "name": "Pingu Exchange",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1969166356009373696/TQYJNyzA_400x400.png",
+    "website": "https://pingu.exchange/",
+    "description": "A perps protocol for trading crypto and real-world assets with leverage.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x605AD21A6A9328d74fA88AA80F23dbD4e746b2fD",
+      "0x4F6e71a81a72Fbd33C599596A7E3e28Aa4b44Ebb",
+      "0x631c6E0d5ae2E1F6a39871a9BE97F1D9d43D1C83",
+      "0x379A14208c15e99177b6A2003B77F38f80D66a2f",
+      "0xE0FfD61De51Ce62D47845c5e6F10c35e8807224d",
+      "0x576d51fB872065DC4Af6f83902fd4078eBCc2f03",
+      "0xe5CdF1b3b36b9799B33E5C6f8C4c8B03848C6470",
+      "0xDD9Bb855fcD8bc3F45b54B9C1F9dE43Dd2DFf06B",
+      "0xCB30DFf8515d4170BBf1fd0Ff01CB21F9ACc4caF",
+      "0x06FC8B836F78A2C95416d33028452f9C95AAc6b4",
+      "0x66700b04bD1a912996fdB90f05c1B0965Fef1b62",
+      "0x1B313E19Df0B33880e99f38AC58e6BbdCC5B1810",
+      "0xD849497f08180d3f1a79397EF8ae4DBD05EC1a5c",
+      "0xD7071C24f765Ca1ad21FF8E9d89ad45845Af64DF",
+      "0xeE6A587C06e02f330C00EA3E7c102d9b1d8a52f3",
+      "0xb1744C2e2B9b34630551338568698368489AEB7f",
+      "0x3d7ec93875B6a6f0A5102fE29f887ee6E751b12F",
+      "0x75F2948bfF7D6D6bb6133cc5FE3c710656c2A939",
+      "0xBfC60682970fd08E2e4eEa96f8B7b6BFa25EAb53",
+      "0xD53b51aE4216B80422216269Edf064E9DE89749b",
+      "0xCf410B10C0f30948033e47b7209CC026054E9F18",
+      "0xe199e871fC628488d6cd1b2d192Ed51Dc8f5b88F",
+      "0xDfD770c6ca5F690289Ddf6a173025719C07996c4",
+      "0x15E5E522a44B562f3c87da77c87eC858F62d221E",
+      "0x133f72734a185ff821705af80D57B8823CA8bC8e",
+      "0x99903470cc631D01F271340C94E224262168ED95",
+      "0xA2426cD97583939E79Cfc12aC6E9121e37D0904d"
+    ]
+  },
+  {
+    "name": "PinotFinance",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1943235355815055360/aCWwgtyJ_400x400.jpg",
+    "website": "https://pinot.finance",
+    "description": "Advanced liquidity and trading hub for Monad powered by real-time voting system.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x0D96571886FE0CbcaFef3109e8B569c7498Ed3fc",
+      "0x89975e0FA4e663BB3D52cE699bDC792aD24C7273",
+      "0x3cBe70c025F045ACACFBeC5119D70b6ebD076b9a",
+      "0x7F00f30D518737A6De6E2A4c9Da39D356ca3a737",
+      "0xA217276C368C9f548F9838863904bE3f9f0D9844",
+      "0x14B8190E024F10A4F0ac0d118aF3F5807FA3fe12",
+      "0x7716F310d62Aee3d009fd94067c627fe7E2f2aA9",
+      "0xb8058cDbC6CdC4b0aA0Aa00A7Ecf7CAAF1441392",
+      "0x252b9C1A6C9867a514ea70fe9bBB23621ACc1a50",
+      "0x22e3d8acB2b32F138018732B6f034e05A46E42f8",
+      "0xfb72484A019F2458B8B609D9230f320f5371A3E3",
+      "0xbC3e14cdbFDd8bb58D1B9A7AA20C316E6b32643D",
+      "0xA8f00b0Df5D4aDa95Fc89E8c389819594Ef45720",
+      "0x82A70cAbe732542996A57455AFfec578b4061322",
+      "0x452146eb925F089A5999976674f40692aD44549C",
+      "0x0a99443B8D303D443BD86186c68C78f3A55c5487",
+      "0xCae374853E8D37C2C8FC6FeA770629054c391756",
+      "0xd7f63BBb5F866258Eb9b9112b6A940D35dbaeb4f"
+    ]
+  },
+  {
+    "name": "Poply",
+    "type": "NFT",
+    "logo": "https://pbs.twimg.com/profile_images/1960818622537814016/3qEMjXr4_400x400.jpg",
+    "website": "https://poply.xyz/",
+    "description": "Community-based NFT Marketplace & Launchpad, built natively on Monad. Launch Freely, Trade Seamlessly.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x81389AEcADcff4b8ae1391d3DceC9a21dE51694C",
+      "0x35a9EaF67C2C6276c8Edf083D5b42eC36214eBd3"
+    ]
+  },
+  {
+    "name": "Primus Token Distribution Platform",
+    "type": "Infrastructure",
+    "logo": "https://avatars.githubusercontent.com/u/111639885?s=200&v=4",
+    "website": "https://pay.primuslabs.xyz",
+    "description": "zkTLS enables rule-based token distribution without ever needing to know the recipient’s wallet address.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xa2e0700a269Be3158c81E4739518b324d4398588",
+      "0x50bd377EB8D4236Bb587AB3FB1eeafd888AEeC58"
+    ]
+  },
+  {
+    "name": "Puffer",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1874641749865607169/08edgUL-_400x400.jpg",
+    "website": "https://www.puffer.fi/",
+    "description": "Puffer is a decentralized native liquid restaking protocol (nLRP) built on Eigenlayer.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x37D6382B6889cCeF8d6871A8b60E667115eDDBcF"
+    ]
+  },
+  {
+    "name": "Purps",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1950588400614166528/MUPvD19X_400x400.png",
+    "website": "http://app.purps.xyz/",
+    "description": "Designed to provide deep liquidity and seamless trading, PURPS enables efficient asset swaps while also serving as an incubator for emerging projects, helping them access liquidity through its powerful launchpad. By combining advanced liquidity mechanisms with a streamlined IDO platform, PURPS ensures that both traders and startups can thrive in the Monad DeFi landscape.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xAfE4d3eB898591ACe6285176b26f0F5BEb894447",
+      "0x22aDf91b491abc7a50895Cd5c5c194EcCC93f5E2",
+      "0x17B4b5F99ec25aAaA644107f86A7756212D4D026"
+    ]
+  },
+  {
+    "name": "Pyth",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1948404937857122304/XPBCFnR5_400x400.jpg",
+    "website": "https://pyth.network",
+    "description": "The price layer of the global financial market.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x2880aB155794e7179c9eE2e38200202908C17B43",
+      "0xD458261E832415CFd3BAE5E416FdF3230ce6F134"
+    ]
+  },
+  {
+    "name": "Rango",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1876978070885695490/lNfhcNta_400x400.png",
+    "website": "https://rango.exchange/",
+    "description": "Rango offers smart routing over DEXs, DEX aggregators, bridges and cross-chain protocols to provides cross-chain swaps, interoperability and message passing",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x69460570c93f9DE5E2edbC3052bf10125f0Ca22d"
+    ]
+  },
+  {
+    "name": "Redstone",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1875180006185246720/rofJl5Xq_400x400.png",
+    "website": "https://redstone.finance/",
+    "description": "RedStone is the fastest-growing Modular Oracle, specializing in yield-bearing collateral for lending markets, such as LSTs, LRTs and BTCFi.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xc44be6D00307c3565FDf753e852Fc003036cBc13",
+      "0xED2B1ca5D7E246f615c2291De309643D41FeC97e",
+      "0x1C9582E87eD6E99bc23EC0e6Eb52eE9d7C0D6bcd",
+      "0x7A9b672fc20b5C89D6774514052b3e0899E5E263",
+      "0x90196F6D52fce394C79D1614265d36D3F0033Ccf",
+      "0x1b0FDa12D125B864756Bbf191ad20eaB10915a6F",
+      "0x0bE6929FD4ad87347e97A525DB6ac8E884FCDCeC",
+      "0x98ECE0D516f891a35278E3186772fb1545b274eB",
+      "0x7A532B1B204409472cB92cd07c8B0BB09DD2F520",
+      "0xD3A0C347b07Fd45F41270D557089B389Fa735C3d",
+      "0xC0FC9416b5c3737E13507f4bAD58cFc016779C84",
+      "0xB3C5BE567817F127412d1758048b376D4D35ec51",
+      "0x6e7407fcd5021e3FE5f75959575b20C85231562d",
+      "0xFFD1339908E0deBE2416E03df0843B896b8944Fe",
+      "0xAd1A270a3F7FF685B90445d9da3EE7Eb22F8A1Ec",
+      "0xB144836c17C5d613Aa471f0BB9B79B55288c2C03",
+      "0x096073133355F874A7D0a857Ffac314dda4e0551",
+      "0x5577797e21FBbB7458f500fa80770D80AAE39bca",
+      "0xa79F7363FCa5118B4141eCeff6dd2A83d5047344",
+      "0xE77456457619ad1948336FBaBC3883cB965b50D1",
+      "0x61669df14B681010A5cfaefc4688Cf9e079ddE5D",
+      "0x63Bb491346fCC8695244D811F0c3501E6C2e8d25",
+      "0xD1136a8C1E5a8Ff204d6875b51158b5Ef1858f60",
+      "0x8C9f39f0D08EE284a4Fe0198524fE7C28630CEAb"
+    ]
+  },
+  {
+    "name": "Rug Rumble",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1988770949446168576/d9Laekir_400x400.jpg",
+    "website": "https://rugrumble.xyz/",
+    "description": "Rug Rumble is a provably fair gaming platform. The Run to a 100x has begun!",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xA33FCf1F510fF1365a7667e3328d042B7d559B8a"
+    ]
+  },
+  {
+    "name": "Sablier",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1163480930910199809/nlJtmWT1_400x400.jpg",
+    "website": "https://sablier.com",
+    "description": "Onchain token distribution. Handle your token vesting, payroll, airdrops, grants, and more with the Sablier Protocol.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xf51BB8bd1cfc7C890dB68c39dCCA67CAd7810Ce4",
+      "0xa0A1aC47260B95D334763473B868117EF7343aA0",
+      "0x1feB172238638897B13b69C65feB508a0a96b35D",
+      "0x619E7f9832522EDeBd883482Cd3d84653A050725",
+      "0x4FCACf614E456728CaEa87f475bd78EC3550E20B",
+      "0xaB15e653cD3bBCe7B7412f81056a450BC0f2e7B9",
+      "0x7DcAB43465c1EbDA92133c92262a6c55394dD69e",
+      "0xfA2Bf3EDdEfE67631BfFA5C53b621A9C6BEbc9C3",
+      "0xCdCc46A7759dE01271E533BBC3b0F32899545a76",
+      "0x0340a829b6dC3aDF7710a5bAF1970914af4977f5",
+      "0x003F5393F4836f710d492AD98D89F5BFCCF1C962"
+    ]
+  },
+  {
+    "name": "Safe",
+    "type": "Infrastructure",
+    "logo": "https://pbs.twimg.com/profile_images/1977658420296630272/BYnU2aa-_400x400.jpg",
+    "website": "https://safe.global/",
+    "description": "Multisig security for your onchain assets",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xf48f2b2d2a534e402487b3ee7c18c33aec0fe5e4",
+      "0x7cbb62eaa69f79e6873cd1ecb2392971036cfaa4",
+      "0xd9db270c1b5e3bd161e8c8503c55ceabee709552",
+      "0x3e5c63644e683549055b9be8653de26e0b4cd36e",
+      "0xa238cbeb142c10ef7ad8442c6d1f9e89e07e7761",
+      "0x40a2accbd92bca938b02010e17a5b8929b49130d",
+      "0xa6b71e26c5e0845f74c812102ca7114b6a896ab2",
+      "0xa65387f16b013cf2af4605ad8aa5ec25a2cba3a2",
+      "0x59ad6735bcd8152b84860cb256dd9e96b85f69da"
+    ]
+  },
+  {
+    "name": "SatLayer",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1963054824397905920/egENXUnR_400x400.png",
+    "website": "https://www.satlayer.xyz/",
+    "description": "The new financial system, built on Bitcoin: SatLayer is the economic layer for Bitcoin, making the best asset now fully programmable.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6CaEAFfC53B91094542B6cB9C51f448DB74dfd8C"
+    ]
+  },
+  {
+    "name": "Sela Network",
+    "type": "AI",
+    "logo": "https://pbs.twimg.com/profile_images/1823231837654945792/8gX3Wmfb_400x400.jpg",
+    "website": "https://www.selanetwork.io/",
+    "description": "Sela Network is a DePIN infrastructure that connects distributed nodes using daily devices, unlocking AI's potential through real-life data accessibility",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x42eA86B7E84ea022aa902C6dC470758BA68A7506"
+    ]
+  },
+  {
+    "name": "Sherpa",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1917218700479901696/1-PQqv8G_400x400.jpg",
+    "website": "https://sherpa.trade",
+    "description": "A suite of user-facing defi applications for automating strategic trading and yield capture methodologies.  Monad focused - multichain enabled.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x96043804D00DCeC238718EEDaD9ac10719778380",
+      "0x58fC8a79055519af779308a60A7f1315cAA266Af",
+      "0xF9BC71BEDEB6ba90de4cf79f09870d99B0ba2bF0",
+      "0xFA82B15CcA7668f011171a026895dde0DefCc46b",
+      "0xF37dD3ACbCB7B3BE161F8F67d09273D5Bc09Bd85",
+      "0x35708afD736873c92134adDBD2c76689993Ab9C4",
+      "0x352c308f0CB6f6B9443CBf38b89e62ca7808A61A"
+    ]
+  },
+  {
+    "name": "Skate AMM",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1873921084871106563/NEW0LSI6_400x400.jpg",
+    "website": "https://skatechain.org",
+    "description": "Unified liquidity DEX powering cross-VM actions",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x0ca6DB88ad5EeC56ca982FB96a24AD2172B4A0eF",
+      "0x430b6E7f7D43D70786267AF7a5B2C1831372ca24",
+      "0x79e31A114E6D2F16E1E2A3EC47C82FAc520881a4",
+      "0xa5646a57EB83Ad2636c08b592D7714d860BE9Fa8",
+      "0x4b13d62a8209b3b25EdCA3046DCb83167F9FeA94",
+      "0xFBD495862410c549f200Ce224Ad3D02a0bAe260D",
+      "0xC2bE4b8852E37ECf979b3E2b5d58162719303804",
+      "0x0B6414dF25eb6D23B7089055885C3d9058b33DEe"
+    ]
+  },
+  {
+    "name": "StakeStone",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1988481903138390016/cRR78wOD_400x400.jpg",
+    "website": "https://stakestone.io",
+    "description": "Autonomous Neo Banking.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x095957CEB9f317ac1328f0aB3123622401766D71",
+      "0xEc901DA9c68E90798BbBb74c11406A32A70652C3"
+    ]
+  },
+  {
+    "name": "Stork",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1899474008195637248/-nVBNuKn_400x400.jpg",
+    "website": "https://www.stork.network/",
+    "description": "Stork, the fastest-growing oracle, offers over 355 real-time feeds for dApps, helping developers build Web2-level speed and efficiency.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62"
+    ]
+  },
+  {
+    "name": "Sumer",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1469005991182143488/ixs_Wjtq_400x400.jpg",
+    "website": "https://www.sumer.money/",
+    "description": "Sumer is a highly capital-efficient blockchain liquidity infrastructure that unifies lending, synthetic assets, and cross-chain liquidity into a single pool. With its synthetic money multiplier, Sumer enables users to earn yields across multiple blockchains without missing native DeFi opportunities on their home chain.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x332F124323A1DA3Aeca4860f3B2B4a4c0df232Ae",
+      "0xBB134359b3E6794127c7232680F959CE6BF60814",
+      "0x0f0af0e3dEb8A884fCB54907BA571c84C2EB3042",
+      "0x2d9b96648C784906253c7FA94817437EF59Cf226",
+      "0x16C7d1F9EA48F7DE5E8bc3165A04E8340Da574fA",
+      "0xe19FD48C972E2dB074C4B0B29Ff2f0d3E1aefe52",
+      "0xF4DB30E806609516D14cDB53D9bc306c99505451"
+    ]
+  },
+  {
+    "name": "Supra Oracles",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1749358202985295872/FcxNf6dw_400x400.png",
+    "website": "https://supra.com/",
+    "description": "Supra Oracles delivers a decentralized, high-performance oracle infrastructure that connects real-world data with smart contracts across a wide range of blockchain platforms.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x58e158c74DF7Ad6396C0dcbadc4878faC9e93d57"
+    ]
+  },
+  {
+    "name": "Swaap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1792539314644983808/W7KOEEmP_400x400.jpg",
+    "website": "https://www.swaap.finance/",
+    "description": "Swaap is the most efficient onchain liquidity source",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xd315a9c38ec871068fec378e4ce78af528c76293",
+      "0xCc74BD5d8D2d333D14475e022325555ebA3369B8"
+    ]
+  },
+  {
+    "name": "Switchboard",
+    "type": "Oracle",
+    "logo": "https://pbs.twimg.com/profile_images/1993016007540031488/gtRyjWYe_400x400.jpg",
+    "website": "https://switchboard.xyz",
+    "description": "Switchboard is a multi-chain, permissionless oracle protocol allowing developers to fully control how data is relayed on-chain to their smart contracts.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x33A5066f65f66161bEb3f827A3e40fce7d7A2e6C"
+    ]
+  },
+  {
+    "name": "Swyrl",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1925440558769872897/j1BXlrTp_400x400.jpg",
+    "website": "https://swyrl.finance/",
+    "description": "Swyrl is a Monad-native DEX with dual AMMs and liquid staking, aligning users and protocols via ve(3,3)-driven governance.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x020e762D529628aDd359a9f4D2f63A3BCFe373Bd",
+      "0xD158CDfeC90E9429A290c3144Afeb72E8C23603a",
+      "0xa6931259B8921F2ED1E7B6c2E657e82873C195ed",
+      "0x10974f1aEE2983b052cD0EF2321Fa7d3edf2B426",
+      "0x02a898F85a6984213Ac6d2577ff3406394172abf",
+      "0x66ae3f94EB3Ab532cC4F8fC8700f6d7488E40A4f",
+      "0x6B096391742bAaEd539Ad25F44dC775065f73322",
+      "0xb79bA9375Fc66C4ddF236BeD3D53ef6213aac7B6",
+      "0xE6c40D7cDc1F1622Ddf2af41ae8c4230A587D133",
+      "0xfDD71E68FE7C3565C5fEaE6Bf3057F9841Fe1F8D",
+      "0x65552047E14028B6c20EB58f305F7663d87013A1",
+      "0xA1164853b6Ad6EfC8B28dEcA0aE5CCbf5CE88328",
+      "0xd8De315eE724CEfD5a4f215daE3d6729e5150a90",
+      "0x95d4063ad9cEDA0d83428986d23BaA9eD5163F58",
+      "0x32D14d57c60A4A213EB4cF76Cb805776D869Bffb"
+    ]
+  },
+  {
+    "name": "Symphony",
+    "type": "AI",
+    "logo": "https://pbs.twimg.com/profile_images/1893386930605211648/-APwnLNM_400x400.jpg",
+    "website": "https://www.symphony.io/",
+    "description": "Symphony is the missing infrastructure layer that connects AI to financial markets. We provide secure, autonomous execution rails so financial platforms can plug in and scale their AI products.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x0e2472E42aE6dF7674C6C4C807cD45F6d47A2A1b",
+      "0xC4a15e24D5aa36c63941B1992A28661bF215e968",
+      "0x527849787Bb79CbEde5ebEd438E685C3B56abB98",
+      "0xE1A5d791F293BA2A32613939D7012B509883EB5e",
+      "0xB64e8Cd2633D4AF5A41a8FDF5e8002FD2f072A83",
+      "0x32aef4656e2cd5b41567225C2933EC72E956e5d0",
+      "0x6E5E5f7adbA00b2e3867DbF2e6E662Eb98208f75",
+      "0x24561A639089126AdDAe7C63c66df668404f94FA",
+      "0xb1Ba36f63569E48E054Eb8BeC0b9A1C13fE2Ac8f"
+    ]
+  },
+  {
+    "name": "TKGasStation",
+    "type": "Infrastructure",
+    "logo": "https://pbs.twimg.com/profile_images/1617589580298846209/P1Shd_R9_400x400.png",
+    "website": "https://turnkey.com",
+    "description": "Gas abstraction for EVM chains that support EIP-7702 using signed intents",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x000066a00056CD44008768E2aF00696e19A30084",
+      "0x00000000008c57a1CE37836a5e9d36759D070d8c"
+    ]
+  },
+  {
+    "name": "Tadle",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1962529150989910017/aa6APvTI_400x400.png",
+    "website": "https://tadle.com/",
+    "description": "The Parallel Sandbox opening a new dimension of accessing dApps.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x89d6AeE63Bd92A9a021d3c4943a66C8e4C8D31f9",
+      "0xA8DD40CE8d5fCA018160D21d5142fB4F938F5453"
+    ]
+  },
+  {
+    "name": "Talentum",
+    "type": "Social",
+    "logo": "https://pbs.twimg.com/profile_images/1887928331066060801/_ahPl-Y4_400x400.jpg",
+    "website": "https://talentum.id/",
+    "description": "An interactive SocialFi platform that blends quests, engagement, and digital collectibles. Earn rewards for meaningful activity, discover new ecosystems, and grow your reputation on-chain.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x4816287183534B5ced5Ee93f098962d7Db144845",
+      "0x5768aF66FcFF11328FDe25398cC61BB201185697",
+      "0xe610baf2D321199be47ba943F2610Bc82bAB774B",
+      "0xf42d150e621b7bE050beb71C0f6E89A63BfaA95F",
+      "0xe3885a21005434c53d945c3A717Bcb23B49412E9",
+      "0x429b401717130d24ED5c92805141442defB6cE1D",
+      "0x05F9DfEf3E95228695BF449d96181b785144b456",
+      "0x28849Cc5A79CE2f94958FF8f853140bce865DAfA"
+    ]
+  },
+  {
+    "name": "Timeswap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1879076220106678272/ZkkhrcyV_400x400.jpg",
+    "website": "https://timeswap.io/",
+    "description": "Timeswap is the first oracleless lending/borrowing protocol that enables the creation of money markets for any ERC-20 tokens. It offers fixed interest lending and borrowing, non-liquidatable loans, isolated risk profiles, and more.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x9515507fC36174e0BAbac382B6640ef2325E61da",
+      "0xBf90d2d8E629cA48CF001F1CA6aDb47f120Fb91a",
+      "0x1c65868b41d5d69146246e3e44b66804d2698C6d",
+      "0x3D7407988B6B3589dcd949B647Fe1F0ec80d5002",
+      "0xCA9Fea121C08F7B71f4625af75c9A8bfC7AdbC3B",
+      "0x69A88955d83d7952142dDA9C688716CA51bC7EeB",
+      "0xC04766f87953C5693C18C976E4b26eF24520B570",
+      "0x49028cb356D9Aa33b996e2Bb17D708044f54d01d",
+      "0x5752513819a784dDc1393b137E9Ac244B17806db",
+      "0x5B598635aECa23690e5B6F3C33C7bD7C79516D62",
+      "0xba37DbAf63c61e056D3C44dBcc7D36898bA54441",
+      "0x48B9837385Ae1C3efC3170207279f1867FC67983",
+      "0x369071882Fa8C1CD3360123Dd9fF2AF4C435D311",
+      "0x53BD5307373d622059CeD2c10E4e8485FE50C4C9",
+      "0xe7C07C840260a9768332C8AF1Ae95941debEA0D1",
+      "0xa37A55Bdf9a3227610b61ef4446670ED4b763B86",
+      "0x0C67b8aa57E66978cC3d11AEE602376429E2A567",
+      "0x7e226A29A54050181d1BFC8A490840F62203F0F4",
+      "0xbc0800cf33Da737a069C8Cf7189C69AAd703F0Fe",
+      "0xCecd8827deF5ba6048d9B374cDA1ABfD9bf857EC",
+      "0x6ef942FAEC47Cac5538f429c734Bf1B98F963a26",
+      "0xBA43a58FC290663415556441098047645910c44D",
+      "0x235272e5e7561505011729b30B2aa57bd9EF6eAC",
+      "0x99359eab05a8E2464bFcaa00eac28E0201845A53",
+      "0x73A76aff6DC8acA146bC7878c5Bf686156D3B519",
+      "0x1c0132b292E34Bb6A05eedB979046e117C8d55dc",
+      "0xCCE1f61DC39e157A63675145a0ffb50065c2F56D",
+      "0xdB81aA023d1b2465a93087Ef829Ae438643939cf",
+      "0xFfc95ED4DB5a43FD3bB9fDAcd2B9409D01167b2a",
+      "0xDca2644D1F0900740158a64cBdc339b0514a4947"
+    ]
+  },
+  {
+    "name": "TownSquare",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1563311542334267398/gaQXK0FD_400x400.jpg",
+    "website": "https://www.townsq.xyz/",
+    "description": "TownSquare is a modular money market that powers crosschain lending & leveraged yield.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xed84c02a0787d56d0b53efe64dd60a1ae20e4e31",
+      "0xb4a545a183bd072548ddfe9ddadc2c6f962ac14f",
+      "0x8f8a0ed366439576b7db220678ed1259743239e3",
+      "0xc2df24203ab3a4f3857d649757a99e18de059a16",
+      "0x428cfa65310c70bc9e65bddb26c65fe4ca490376",
+      "0xc4c20efbefa4bde14091a3040d112cf981d8b2db",
+      "0x2970fde6064178d51d961689cb5b64226ab11fc2",
+      "0x2dfdb4bf6c910b5bbbb0d07ec5f088e294628189",
+      "0x63cb1cf5accbcc57e0cca047be9673ea5022b8db",
+      "0x0392354326960f891926835eedab127766b21668",
+      "0xa457235b68606a7921b7c525d92e9592e793b4c0",
+      "0xa2b1ac2bb0a6ad5e74d74f8809a2f935813d273a",
+      "0xdb4e67f878289a820046f46f6304fd6ee1449281",
+      "0xf358f9e4ba7d210fde8c9a30522bb0063e15c4bb",
+      "0x106d0e2bff74b39d09636bdcd5d4189f24d91433"
+    ]
+  },
+  {
+    "name": "Uniswap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1831348758753206272/y2Z0hMrl_400x400.jpg",
+    "website": "https://app.uniswap.org/",
+    "description": "The largest onchain marketplace. Buy and sell crypto on Ethereum and 11+ other chains.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x182a927119d56008d921126764bf884221b10f59",
+      "0x4b2ab38dbf28d31d467aa8993f6c2585981d6804",
+      "0x204faca1764b154221e35c0d20abb3c525710498",
+      "0xd1b797d92d87b688193a2b976efc8d577d204343",
+      "0x661e93cca42afacb172121ef892830ca3b70f08d",
+      "0xf025e0fe9e331a0ef05c2ad3c4e9c64b625cda6f",
+      "0x2e9d45bb7b30549f5216813ada9a6b7982c5b3ed",
+      "0x315e413a11ab0df498ef83873012430ca36638ae",
+      "0x7197e214c0b767cfb76fb734ab638e2c192f4e53",
+      "0x7078c4537c04c2b2e52ddba06074dbdacf23ca15",
+      "0xd6145b2d3f379919e8cdeda7b97e37c4b2ca9c40",
+      "0x188d586ddcf52439676ca21a244753fa19f9ea8e",
+      "0x5770d2914355a6d0a39a70aeea9bcce55df4201b",
+      "0x5b7ec4a94ff9bedb700fb82ab09d5846972f4016",
+      "0xa222dd357a9076d1091ed6aa2e16c9742dd26891",
+      "0x77395f3b2e73ae90843717371294fa97cc419d64",
+      "0x2d01411773c8c24805306e89a41f7855c3c4fe65",
+      "0x0d97dc33264bfc1c226207428a79b26757fb9dc3",
+      "0x5c834b6cac4173bfe288c5722a38e04b9e366e30"
+    ]
+  },
+  {
+    "name": "Upfloor",
+    "type": "NFT",
+    "logo": "https://pbs.twimg.com/profile_images/1979463970391035904/doN2Je6V_400x400.jpg",
+    "website": "https://upfloor.co/",
+    "description": "Transforms NFT collections into perpetual growth engines",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xB16EAa34cA11291a70Acfc16440F3aABAf89E332"
+    ]
+  },
+  {
+    "name": "Wormhole",
+    "type": "Bridge",
+    "logo": "https://pbs.twimg.com/profile_images/1967993658080133120/VSOooFaD_400x400.jpg",
+    "website": "https://wormhole.com/",
+    "description": "Wormhole is a generic message-passing protocol designed to enable secure and efficient communication between different blockchains. ",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x194B123c5E96B9b2E49763619985790Dc241CAC0",
+      "0x0B2719cdA2F10595369e6673ceA3Ee2EDFa13BA7",
+      "0x36878C6FCa7e0E8a88F90dc410CfBBcA5B695C95",
+      "0x92957b3D0CaB3eA7110fEd1ccc4eF564981a59Fc",
+      "0x1a0f31492Ca69DF6A82906Ce88613AeCD9245C44",
+      "0x7e0AF7c98CBf443B345d718C3787f3f86AdbC51D",
+      "0xf3C52C28Ddd282a96841933bb0Cb85Ba0fCB2FA0",
+      "0x0DAB1c1733F1a9b84c90b08Da78Db014B3b13AB5",
+      "0xC04dE634982cAdF2A677310b73630B7Ac56A3f65",
+      "0xA4d775410FB35d8cE49Ad98d3f483A55e532de73",
+      "0xD64341A38a5eAfb9EB9BACf8A5C52Fe858c4ABE9",
+      "0x93FE94Ad887a1B04DBFf1f736bfcD1698D4cfF66",
+      "0xFEA937F7124E19124671f1685671d3f04a9Af4E4",
+      "0x0E4Eaf9c5c74bec4Cb651394db4847f77700e175",
+      "0x13b62003C8b126Ec0748376e7ab22F79Fb8bbDF2",
+      "0xf7E051f93948415952a2239582823028DacA948e",
+      "0x412f30e9f8B4a1e99eaE90209A6b00f5C3cc8739"
+    ]
+  },
+  {
+    "name": "Yap Market",
+    "type": "Social",
+    "logo": "https://pbs.twimg.com/profile_images/1915456612401025024/a4kyUymg_400x400.jpg",
+    "website": "https://yap.market/",
+    "description": "Yap Market is an on-demand attention marketplace built on Kaito that helps crypto projects launch high-impact distribution campaigns. We reward creators for real results from engagement to onchain conversions, not vanity metrics.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x29957e3b3DaBeDBE830b0De53C2C9293d0DB1bda"
+    ]
+  },
+  {
+    "name": "aPriori",
+    "type": "LST",
+    "logo": "https://pbs.twimg.com/profile_images/1821177411796410369/GtzmUXok_400x400.jpg",
+    "website": "https://www.apr.io/",
+    "description": "The intelligent order flow coordination layer for high performance blockchains",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x0c65A0BC65a5D819235B71F554D210D3F80E0852",
+      "0x77F6e4103e32D6146e29cF9eD1645e170F90BC2b"
+    ]
+  },
+  {
+    "name": "earnAUSD",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1853600042952663040/AwOMmTi1_400x400.jpg",
+    "website": "https://upshift.finance",
+    "description": "The primary liquid yield token on Monad, systematically allocating AUSD across top DeFi opportunities",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x36eDbF0C834591BFdfCaC0Ef9605528c75c406aA",
+      "0x04ae5a71eA943f9Fc4ECB3BD4118e381cD04067D",
+      "0x103222f020e98Bba0AD9809A011FDF8e6F067496",
+      "0x942147E26B4F320b1f1D34895497aB59a56DceeC",
+      "0x95f3458Cb7FE0fd8D22DA406F688aa6Ac74AEa84",
+      "0xceA701f0Ff0a2e8A51a5C5c1D2B6b69BFA849989",
+      "0x0000000000000000000000000000000000000000"
+    ]
+  },
+  {
+    "name": "ESP.Fun",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1963349327998230528/RVQ-t5AG_400x400.jpg",
+    "website": "https://esp.fun/",
+    "description": "ESP.Fun is a fantasy esports gaming platform featuring player tokens, pack opening systems, and decentralized trading via automated market maker pools.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xC99a1D62a453481B24C5364403E61c4254218d28",
+      "0x3C1bCd19455f3fA33234fAf9c73F9E6EA055A899",
+      "0x26448Da45e80709B3E4ADfFa4a98c62925ea836f",
+      "0x7F51991A3C9c779a841caefeEE4c0167BF6f871A",
+      "0x5159373fe2D88BbC217a9860AE739eb3294d9e12",
+      "0x81dE118EaECa76df364458d76Ad1f2F02fA7C238",
+      "0xE4DcbD655aCBf413097CaF4576a4d9dB05aCc015"
+    ]
+  },
+  {
+    "name": "iZiSwap",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1509704804032937991/5qVVZwJj_400x400.jpg",
+    "website": "https://izumi.finance/trade/swap",
+    "description": "A multi-chain DeFi protocol providing One-Stop Liquidity as a Service (LaaS).",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x8c7d3063579BdB0b90997e18A770eaE32E1eBb08",
+      "0x4d4673745AAC664eFB9758fdd571F40d78a87bfe",
+      "0x32D02Fc7722E81F6Ac60B87ea8B4b63a52Ad2b55",
+      "0xF4efDB5A1E852f78e807fAE7100B1d38351e38c7",
+      "0xe96526e92ee57bBD468DA1721987aa988b008768",
+      "0xbD6abA1Ef82A4cD6e15CB05e95f433ef48dfb5df",
+      "0x19b683A2F45012318d9B2aE1280d68d3eC54D663",
+      "0x02F55D53DcE23B4AA962CC68b0f685f26143Bdb2",
+      "0x2db0AFD0045F3518c77eC6591a542e326Befd3D7",
+      "0x3EF68D3f7664b2805D4E88381b64868a56f88bC4",
+      "0x33531bDBFE34fa6Fd5963D0423f7699775AacaaF",
+      "0x34bc1b87f60e0a30c0e24FD7Abada70436c71406",
+      "0x3F559139C2Fc7B97Ad6FE9B4d1f75149F551DB18",
+      "0x04830cfCED9772b8ACbAF76Cfc7A630Ad82c9148",
+      "0x2C6Df0fDbCE9D2Ded2B52A117126F2Dc991f770f",
+      "0x14323AfbC2b82fE58F0D9c203830EE969B4d1bE2"
+    ]
+  },
+  {
+    "name": "Kansei",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1965511338270052352/Ro1SsJIM_400x400.png",
+    "website": "https://kansei.finance/",
+    "description": "All-in-one trading / yield leverage / liquid staking SuperApp with near instant UX.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x6B672532B4347B56236ceeD8a2410Aec4395FdB2",
+      "0x33d4220003A120b07F0A764a6C9A70e6D328C461",
+      "0xDa3A330073c10eB00AFc322F77BC24ed289D083F",
+      "0xe665DE7AAD6B20cAfa4BEe85b6B27a4000b106e4",
+      "0xcB79E3EdB6Bf3d7e66e3f685cd9F2373F462f4f3",
+      "0x8F8420CFeD0B9F84f3b4c593494D288F8a4A84C4",
+      "0x41D5eF83d666Bed43D78bc467C844512f27F5d03",
+      "0xaD2074EBBd819f47aC936CDADC5F3FC8A6609f00",
+      "0xeBA09ADcb1D0052745CEadf0e9c3A87E2Ab11B2f",
+      "0x0493B0f962346AadCaB77ABc6d24a9c69A74962b",
+      "0x58BA4Db931da0509b7F0b7477925dE3e9a20CE1A",
+      "0x2632662f3750EE27b025D44ADFF0B86839D0BeC1",
+      "0x4834a84C17c2a449054e0ad1e0FC63cd5512bFd2",
+      "0xfD792edCe7926484c560466A6A4C7952602670EA"
+    ]
+  },
+  {
+    "name": "Lagoon",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1990443288290013184/3nySPoed_400x400.png",
+    "website": "https://www.lagoon.finance/",
+    "description": "LAGOON provides open, general-purpose, secure vault infrastructure to build and scale on-chain yield products.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xBf994c358f939011595AB4216AC005147863f9D6",
+      "0xcCdC4d06cA12A29C47D5d105fED59a6D07E9cf70"
+    ]
+  },
+  {
+    "name": "Mevx",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1991722130132828160/DySjqo2x_400x400.jpg",
+    "website": "https://mevx.io/",
+    "description": "MevX is your go-to platform for all things crypto trading and data analysis",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x92ef088BC025EBaf7C9521dFa82130d33934EB30",
+      "0xd1f47ef81354663F3786b62B5B95C1015dA48CA4",
+      "0xC67134cc40765fc28e2d54f58Cd93d382D9137d8",
+      "0xa26326Af694D03A12250df01733B173c05153A76",
+      "0xf867f2bfd6C1926770E6451A72B2899231678A56"
+    ]
+  },
+  {
+    "name": "Morpho",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1990342665846599680/V6YT8dQv_400x400.jpg",
+    "website": "https://morpho.org/",
+    "description": "The universal lending network",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xA16B49505e39C373A8f9e1b1540514BA64B3942a",
+      "0xD5D960E8C380B724a48AC59E2DfF1b2CB4a1eAee",
+      "0x09475a3D6eA8c314c592b1a3799bDE044E2F400F",
+      "0xe27f43624FDb5325b853c4711BCF0fEBA754e558",
+      "0xfd70575B732F9482F4197FE1075492e114E97302",
+      "0x6C3A89e814A9D150cD763f443dceE5EBC5bF60b6",
+      "0x907a393Ad715Ac63389EEc3236FaC74E7D68a4ee",
+      "0x33f20973275B2F574488b18929cd7DCBf1AbF275",
+      "0xC8659Bcd5279DB664Be973aEFd752a5326653739",
+      "0x0a3c9f732C7E987ddbBaac13309A8B552aa50872",
+      "0x6F12916F559dC7f86a86cD3e33BFebE6348f979A",
+      "0xE8233125be3ecD274b8007618315Dd2f3361eced",
+      "0x6D0090dB99919d1594B9b824D295E923266C9052",
+      "0x6A99Cc46825A724B41f8E5656935929FA0a2cB2C",
+      "0xA3E73eC1792bb127B0915dE9842eB999C12C0c34",
+      "0xFf08983fAA3D689c8C8527Bd69f90Ea46d170db9",
+      "0x03877DB7cAa28bC522DbB8c060eeAEB086020B83",
+      "0xB5b3e541abD19799E0c65905a5a42BD37d6c94c0",
+      "0x82b684483e844422FD339df0b67b3B111F02c66E",
+      "0x725AB8CAd931BCb80Fdbf10955a806765cCe00e5",
+      "0x273dBC3f178D03fA9D385e61Ee1E11dCf563EE14",
+      "0xF4c840eA6fdD0493F77Ef0141C5a5a09Cd384918",
+      "0x22C3024C7E1e149d7E49766cd047a2da081E4EAF",
+      "0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c",
+      "0x8Da54fbF89B3D6fC6DCC92F31CF75a211ACF3d46",
+      "0x9f3c0999425656fD189C69a8aD68cB64986D644A",
+      "0xc1108C5d98DC09BE44e656A9E34B04D37b90a50d",
+      "0xD155AF55cF966886cc197F05399bE4a033af7090",
+      "0x549bf7A3346eBEbe88BD3FcaD8Ab1f23De8Eb4e4",
+      "0xa1a2ca8feB4d08a7123BFBB0A269501F885264DE",
+      "0x71dd91258eca11fC045098774Ec2F331126A0b53",
+      "0x6a42f8b46224baA4DbBBc2F860F4675eeA7bd52B",
+      "0xF5e6DD4b06874f55444936cF0026b785383A9849",
+      "0x1d721eddac84e1B9995Fc25ce3e57463688064a9",
+      "0x3f12264881a118C2A74Ad10F9039694579bdCf54"
+    ]
+  },
+  {
+    "name": "TeleMafia",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1967887075316994050/STzEqU1y_400x400.jpg",
+    "website": "https://mafia.family/",
+    "description": "TeleMafia is a Telegram-native social mafia RPG where Families compete, earn Respect, and grow shared on-chain Treasuries powered by Monad.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xA5A6F68A3fcE8D345Be024d0E0Bf4240Bc620Be4",
+      "0x777AcAb541A663ABbad28de92Af6caeFD67c72CD",
+      "0xaE2DfCa11311e1652B9d3dC39527465435eA94ef",
+      "0x5d1814D6981247bc796CA3F48d5Cc382dd552552",
+      "0xCbA51d62D0B240Bb8f60eee98351464beaa5Cc77"
+    ]
+  },
+  {
+    "name": "Thevapelabs",
+    "type": "DePIN",
+    "logo": "https://pbs.twimg.com/profile_images/1844811987034972160/OkkeVD3C_400x400.jpg",
+    "website": "http://thevapelabs.io",
+    "description": "TheVapeLabs is the world’s first AI-powered smart vape brand, built on Monad. We help people cut down and quit nicotine with real-time tracking, personalized AI tips and incentives. Users can even flex their NFTs right on the device, bringing on-chain culture into real life.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xfA2F863Eb512434E99E2365Fa5f7AC7674DDe000",
+      "0x51FFf43eb9Cc9cE9de491E86dcfBFbf0864cfEED",
+      "0x925726a0AAbB82464d21F6795A457fA9Fe0a57c1"
+    ]
+  },
+  {
+    "name": "SLAB CASH",
+    "type": "Collectibles",
+    "logo": "https://pbs.twimg.com/profile_images/1944817732647542784/KOF2eYVo_400x400.png",
+    "website": "https://slab.cash",
+    "description": "Level up your collection with physical backed, onchain authenticated trading cards.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xC2DC75bdd0bAa476fcE8A9C628fe45a72e19C466",
+      "0x8a981C2cfdd7Fbc65395dD2c02ead94e9a2f65a7",
+      "0xb85D2443aEfbCaf9f0b32EAde7D47BeBc5D00972"
+    ]
+  },
+  {
+    "name": "Memenads",
+    "type": "DeFi",
+    "logo": "https://pbs.twimg.com/profile_images/1993957015132209153/v64sdIcG_400x400.jpg",
+    "website": "https://memenads.fun",
+    "description": "Memenads.fun is a one-click meme token launchpad that lets anyone create, deploy, and trade meme coins instantly. No coding required—launch your token in seconds and grow your community with built-in tools.",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x0d3c2cfab83920236f266e70076b0d502cd060d0",
+      "0x5f810dd164668ef52f60bf7e9830ac2dc3f7b1e8"
+    ]
+  },
+  {
+    "name": "Wordle Fun",
+    "type": "Gaming",
+    "logo": "https://pbs.twimg.com/profile_images/1994437577475035136/VwjOn7jE_400x400.jpg",
+    "website": "https://www.wrdl.fun/",
+    "description": "Wrdl.fun is an on-chain word game built on Monad, inspired by the iconic Wordle format and enhanced with real on-chain incentives",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x6FBB86d5940B11E23056a66a948d97289Bd320eB"
+    ]
+  },
+  {
+    "name": "Curvance",
+    "type": "Lending",
+    "logo": "https://imagedelivery.net/cBNDGgkrsEA-b_ixIp9SkQ/Curvance.png/public",
+    "website": "https://www.curvance.com/",
+    "description": "Click Less, Earn More.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0x1e240E30E51491546deC3aF16B0b4EAC8Dd110D4",
+      "0x926C101Cf0a3dE8725Eb24a93E980f9FE34d6230",
+      "0x8EE9FC28B8Da872c38A496e9dDB9700bb7261774",
+      "0xE01d426B589c7834a5F6B20D7e992A705d3c22ED",
+      "0xAd4AA2a713fB86FBb6b60dE2aF9E32a11DB6Abf2",
+      "0x0fcEd51b526BfA5619F83d97b54a57e3327eB183",
+      "0x6E182EB501800C555bd5E662E6D350D627F504D8",
+      "0x852FF1EC21D63b405eC431e04AE3AC760e29263D",
+      "0xfD493ce1A0ae986e09d17004B7E748817a47d73c",
+      "0x2B4e0232F46E6DB4af35474c140B968EeFCB09Ec",
+      "0xF32B334042DC1EB9732454cc9bc1a06205d184f2",
+      "0xD9E2025b907E95EcC963A5018f56B87575B4aB26",
+      "0x92EE4b4d33Dc61bd93a88601F29131B08aCedBF1",
+      "0x5af9b7cAc0530d3C9e11C23B7A69Cce335B8C395"
+    ]
+  },
+  {
+    "name": "zkSwap Finance",
+    "type": "DeFi",
+    "logo": "https://assets.coingecko.com/coins/images/31633/standard/200x200_Black.png",
+    "website": "https://www.zkswap.finance",
+    "description": "A multichain decentralized exchange that offers a Swap2Earn model, designed to provide incentives for both liquidity providers and traders",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xF82343c8b777BAdB0921ee4c4F7581c968687B6b",
+      "0xC60cBC14D170A95938bb630AE78a8306dd7cF120",
+      "0x68225b5ba7cE309fD0d3f0C9A74b947c7d7e03dA",
+      "0x0ff16867BcaC3C5fdc2dc73558e3F8e2ed89EEA2",
+      "0xf5Cf2b71B8B368c84C4C4903AF453E790d392285",
+      "0xCe98a0E578b639AA90EE96eD5ba8E5a4022de529",
+      "0x98356a6276e0413FF21d41a17EB851dB9207A285",
+      "0xC5AB2BE64e27e43778C9AA692cf058ba043BC32a",
+      "0xb41bFa454808eE4d35638a225cc91389A5295e7F",
+      "0xcf7ff4717D5E1468C82aA69Dba8dAcb18eD5B585",
+      "0x734711633eF2c9a2386BE0eA1C010b06FB3b94Aa",
+      "0x45728A3D03fF67Cc0c8546f4290aFFB7C94F877a",
+      "0x486D7C009B78310528AcA11574eC816d2FdEf71B",
+      "0x2f2f2f74ab5db61AE8BD3c13ccD4Dc8c9E8A2f2f",
+      "0x123468b48EADbC13c65cd9c66A9913cdE4e94321",
+      "0x0aa3e6692e4E8845e21867b520A2Bb0377199350",
+      "0xF5AC2cE5002272EA0042a4Ba3dcBb45fd2b8A021"
+    ]
+  },
+  {
+    "name": "MonBridgeDex",
+    "type": "DeFi",
+    "logo": "https://avatars.githubusercontent.com/u/210091763?s=400&u=d0acd4299e071def2fe61e0acd6216deda67d320&v=4",
+    "website": "https://monbridgedex.xyz",
+    "description": "Mon Bridge Dex is an advanced aggregator that bridges multiple DEXes to secure the best swap output for your trades on Monad",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x7dd7fc9380e3107028a158f49bd25a8a8d48b225",
+      "0xd2748ceA2ADa9Bfc4eDA8AD7fe170f8a6A0EABe8"
+    ]
+  },
+  {
+    "name": "Color - RgbClash",
+    "type": "Game",
+    "logo": "https://www.rgbclash.xyz/center_filled.png",
+    "website": "https://www.rgbclash.xyz/",
+    "description": "Unleash your creativity and draw your yield bearing NFTs. Play to earn with multiplayer drawing-guessing game.",
+    "monad_exclusive": false,
+    "contracts": [
+      "0xC8bB93e4f11665D76C704d973e744d78b3d32A2c",
+      "0x2aF76C4e57886Aac03329a6dfF02761F250848A3",
+      "0xb25Ef8643414e6bb29E9eF24E8fD7dC9115b26e1",
+      "0x1f5E4a0fFaB85E5BBa68f73f878117eD314e4452",
+      "0x9Cc79CE554a6CebCE2EC90DAb0F77E6b08e89563"
+    ]
+  },
+  {
+    "name": "dFusion AI",
+    "type": "AI, Infrastructure",
+    "logo": "https://cdn.prod.website-files.com/660ab3687f4b08443800247f/672240e6f55de869b96f325e_Light%20Logo.svg",
+    "website": "https://testnet.dfusion.ai",
+    "description": "dFusion AI turns curated data into specialized & accurate AI subnets, aligning usage, incentives, and ownership.",
+    "monad_exclusive": true,
+    "contracts": [
+      "0x9ED42CeBA267C3f7728Cc1F559cd7b545D7CD7d4"
+    ]
+  },
+  {
+    "name": "Monday Trade",
+    "type": "DeFi",
+    "logo": "https://mondaytrade.notion.site/Monday-Trade-Brand-Kit-1f948d36614f807bb374c003d7c35e70",
+    "website": "https://app.monday.trade",
+    "description": "Monday Trade is Monad’s native spot and perps DEX that offers the best of CEX and DEX trading experience",
+    "monad_exclusive": true,
+    "contracts": [
+      "0xAD8974D98f7fc386e396FFE826B886cf20AfE232",
+      "0x68b507BF58ED32173f41FF20aa2494A569daeC44",
+      "0xB97eCD41Aef0F842E773C8F9905919cDE49880C9",
+      "0xFE951b693A2FE54BE5148614B109E316B567632F",
+      "0xC1e98D0A2a58fB8aBd10ccc30a58efff4080Aa21",
+      "0xdc67221ea8D223E0A1D0948eDeCB634cAF190eC9",
+      "0x15bC3C13cbf5903E78b97208ba1021E5dc1B4470",
+      "0x2E32345Bf0592bFf19313831B99900C530D37d90",
+      "0xdfBA572929De47838BdE12336dfE8842B06d9628",
+      "0x5FE49fb8770A8009335B1d76496c3e07Ca04FC9F"
+    ]
+  }
 ]


### PR DESCRIPTION
## Summary
Added 11 new V4 contract addresses for Nar.bet casino on Monad mainnet. 

V4 contracts use Pyth Entropy V2 and UUPS upgradeable proxy pattern. All previous contract addresses are retained.

New proxy addresses:
- CoinFlip: `0xb82360d08784f0Ff24A740ADaD6b1AC2391C8D57`
- Range: `0x0B1E533e33f9E82849E71fb5c0a33F38462D5eD4`
- RockPaperScissors: `0x843D62ad75F5d0b383f8520e23d19174b7961b8E`
- Slots: `0xd6F08aF222C8aa69F99B6099F93C6d96897d378f`
- Plinko: `0x5859E2926750F3981f95bbA16b86d8e69cf4334B`
- Mines: `0x3014d056Db789984552084Db359D7C56A620549b`
- VideoPoker: `0xb86A1955E96147665d7bdd70E50bD6Af38E086d1`
- Baccarat: `0x8261A173DC96e206b8D8621ca1231a3E7bcB851E`
- Roulette: `0x4A050DD00c08856cc3d7C5BD152E4e601ffDaa35`
- Limbo: `0xb9e0b5447B92eb5CF246693F7b533d5c84AA8dC5`
- FishPrawnCrab: `0xbbE3FA39912355C49Aa3ccdD02C51d989Fb33E79`